### PR TITLE
Allow it to build on linux ARM cpu

### DIFF
--- a/src/tdebug.cpp
+++ b/src/tdebug.cpp
@@ -122,6 +122,10 @@ static void printstacktrace(void * uap, void * data) {
     } else {
         ucontext_t * uc = (ucontext_t*) uap;
 #ifdef __linux__
+#if defined(__arm__)
+        rip = (void*) uc->uc_mcontext.arm_pc;
+        rbp = (void*) uc->uc_mcontext.arm_fp;
+#else
         rip = (void*) uc->uc_mcontext.gregs[REG_RIP];
         rbp = (void*) uc->uc_mcontext.gregs[REG_RBP];
 #else


### PR DESCRIPTION
When testing terra on a ubuntu ARM cpu it was not compiling due to a reference to non existing registers.
With this fix it can be compiled I've got this results for tests:
```
=================
= FAILING tests
=================
painfulrecstruct.t
simplevec.t
class.t
fnpointer.t
benchmark_fannkuchredux.t
quote9.t
huge.t
aggregatearr.t
pretty.t
macro.t
speed.t
new.t
nolengthop.t
intrinsic.t
luabridge.t
interface2.t
isvolatile.t
blocking.t
hello.t
coverage3.t
bounce.t
pt.t
symbolvar4.t
usercast.t
nestextract.t
testdebug.t
nontemporal.t
symbolvar6.t
class3.t
antiquote3.t
or.t
blocking3.t
atoi.t
arraylit.t
symbolvar7.t
vecarith.t
stattest.t
vec.t
class6.t
sintable.t
ssimple.t
evenodd.t
quote3.t
clean.t
recfn.t
vars2.t
union.t
unpacktuple.t
globals.t
vars.t
hasbeenfrozen.t
benchmark_nbody.t
veclit.t
fib2.t
cnames.t
mathlib.t
shift.t
dgemmpaper.t
selectoverload.t
numliteral.t
fastcall.t
examplecompiler1.t
forbreak.t
gettype.t
quote5.t
localenv.t
call.t
quote7.t
terraluamethod.t
sgemm-old.t
cstruct.t
and.t
quoteselect.t
paren.t
diffuse.t
for.t
hello2.t
stencil.t
terranew.t
bug2.t
includec.t
simple.t
multiconstructor.t
ainline.t
printfarray.t
luabridgeunion.t
class5.t
rvaluerecv.t
renaming.t
blocking2-fixed.t
zeroreturn.t
nojit.t
string.t
ifelse.t
bf.t
exportdynamic.t
twolang.t
cunion2.t
let1.t
bug4.t
callbackcache.t
terralua.t
constant2.t
interface.t
arith.t
malloc.t
constant.t
expvec.t
forsym.t
coverage2.t
zeroreturn2.t
parsefail.t
cconv.t
symbolvar5.t
explicitcast.t
special.t
pthreads.t
fnptrc.t
avxhadd.t
printfloat.t
sgemm.t
gvarfault.t
torturechain.t
quote10.t
fakeasm.t
gcbug.t
antiquote2.t
pointerarith.t
class4.t
luabridge2.t
multiterra.t
luabridgefn.t
pow.t
recstruct.t
arrayt.t
completec.t
fnptr.t
quote6.t
luaterramethod.t
simpleglobal.t
incomplete3.t
let2.t
class2.t
cnamespace.t
blocking2.t
terracast.t
```

277 tests passed. 146 tests failed.

------------------ using mcjit "-m" option we get
```
= FAILING tests
=================
class.t
benchmark_fannkuchredux.t
quote9.t
huge.t
speed.t
nolengthop.t
luabridge.t
hello.t
coverage3.t
symbolvar4.t
usercast.t
nestextract.t
testdebug.t
symbolvar6.t
or.t
arraylit.t
symbolvar7.t
vecarith.t
vec.t
class6.t
ssimple.t
clean.t
union.t
unpacktuple.t
globals.t
benchmark_nbody.t
veclit.t
cnames.t
mathlib.t
shift.t
selectoverload.t
fastcall.t
examplecompiler1.t
gettype.t
call.t
cstruct.t
and.t
terranew.t
includec.t
multiconstructor.t
luabridgeunion.t
class5.t
renaming.t
ifelse.t
exportdynamic.t
twolang.t
cunion2.t
let1.t
constant2.t
arith.t
expvec.t
parsefail.t
cconv.t
symbolvar5.t
explicitcast.t
special.t
avxhadd.t
sgemm.t
torturechain.t
quote10.t
antiquote2.t
luabridge2.t
multiterra.t
pow.t
arrayt.t
quote6.t
let2.t
cnamespace.t
```

356 tests passed. 68 tests failed.
