### PR TITLE
Add support for importing external global variables from C

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1105,7 +1105,18 @@ static GlobalVariable * GetGlobalVariable(terra_State * T, Obj * global, const c
         Obj t;
         global->obj("type",&t);
         Type * typ = Types(T).Get(&t)->type;
-        
+
+        if(global->boolean("isextern")) {
+            const char * _name = name;
+            if(global->hasfield("name")) _name = global->asstring("name");
+            gv = T->C->m->getGlobalVariable(_name);
+            if(gv) {
+                lua_pushlightuserdata(T->L, gv);
+                global->setfield("llvm_value");
+                return gv;
+            }
+        }
+
         Constant * llvmconstant = global->boolean("isextern") ? NULL : UndefValue::get(typ);
         Obj constant;
         if(global->obj("initializer",&constant)) {
@@ -2846,6 +2857,3 @@ static int terra_dumpmodule(lua_State * L) {
     T->C->m->dump();
     return 0;
 }
-
-
-

--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -500,6 +500,43 @@ public:
         F->setBody(stmts);
         return F;
     }
+    DeclRefExpr * GetVarReference(VarDecl * v) {
+        DeclRefExpr *DR = DeclRefExpr::Create(*Context, NestedNameSpecifierLoc(),SourceLocation(),v, false, SourceLocation(),
+                          v->getType(),
+                          VK_LValue);
+        return DR;
+    }
+    void KeepVarLive(VarDecl * v) {
+        Expr * castexp = CreateCast(Context->VoidTy, clang::CK_ToVoid, GetVarReference(v));
+        outputstmts.push_back(castexp);
+    }
+    bool TraverseVarDecl(VarDecl *v) {
+        if(!v->hasGlobalStorage() || !v->hasExternalStorage())
+            return true;
+
+        QualType t = v->getType();
+        Obj typ;
+
+        if(!GetType(t, &typ))
+            return true;
+
+        std::string name = v->getNameAsString();
+        CreateExternGlobal(name, &typ);
+        KeepVarLive(v);
+
+        return true;
+    }
+    void CreateExternGlobal(const std::string & name, Obj * typ) {
+        if(!general.hasfield(name.c_str())) {
+            lua_getfield(L, LUA_GLOBALSINDEX, "terra");
+            lua_getfield(L, -1, "externglobal");
+            lua_remove(L, -2); //terra table
+            lua_pushstring(L, name.c_str());
+            typ->push();
+            lua_call(L, 2, 1);
+            general.setfield(name.c_str());
+        }
+    }
   private:
     std::vector<Stmt*> outputstmts;
     std::vector<QualType> outputtypes;

--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -1132,6 +1132,12 @@ do  --constructor functions for terra functions and variables
         return fn
     end
 
+    function terra.externglobal(name, typ)
+        local gbl = terra.global(typ, nil, true)
+        gbl.name = name
+        return gbl
+    end
+
     function terra.definequote(tree,envfn)
         return terra.newquote(terra.specialize(tree,envfn(),2))
     end


### PR DESCRIPTION
I wanted to interface better with the GLEW library like mentioned in #71, so I did my best to implement the importing of global variables.  It seems to work for both simple cases like
```lua
C = terralib.includec("stdio.h")
terra main()
        C.fprintf(C.stdio, "Hello, world!")
end
main()
```
as well as with more complicated cases, like global function pointers.  (the KeepVarLive seems to be only necessary for function pointers, for some reason.)  If there's anything more complicated that I'm missing, I'm not aware of it.

I've never worked with the LLVM or Lua APIs before, so if you have the time, I'd appreciate it if you could look over my changes.  Thanks.