### PR TITLE
Return an exit code from the test runner on fail

### DIFF
--- a/tests/run
+++ b/tests/run
@@ -57,3 +57,7 @@ end
 printtests("passing tests",passed)
 printtests("FAILING tests",failed)
 print(tostring(#passed).." tests passed. "..tostring(#failed).." tests failed.")
+
+if #failed then
+    os.exit(1)
+end


### PR DESCRIPTION
Useful for automated testing (a `test` method in a Homebrew package in my case).