### PR TITLE
Fixed not finding internalizedfiles on Mint 17.2

### DIFF
--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -657,8 +657,9 @@ public:
   virtual ~LuaOverlayFileSystem() {}
 
   virtual llvm::ErrorOr<clang::vfs::Status> status(const llvm::Twine &Path) override {
+    static const std::error_code noSuchFileErr = std::make_error_code(std::errc::no_such_file_or_directory);
     llvm::ErrorOr<clang::vfs::Status> RealStatus = RFS->status(Path);
-    if (RealStatus || RealStatus.getError() != std::errc::no_such_file_or_directory)
+    if (RealStatus || RealStatus.getError() != noSuchFileErr)
         return RealStatus;
     clang::vfs::Status Status;
     StringRef Buffer;


### PR DESCRIPTION
I assume the problem has the same root on the various *nixs where it has
occured. The problem was the comparison of the `std::error_code` and
`std::errc` on this platform. Creating an "real" `error_code` object to
compare against fixes the problem. Still working on my mac after this change.
fixes #137