### PR TITLE
couple build fixes for terra+cuda on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ CLANG_PREFIX ?= $(LLVM_PREFIX)
 endif
 
 CUDA_HOME ?= /usr/local/cuda
-ENABLE_CUDA ?= $(shell test -e /usr/local/cuda && echo 1 || echo 0)
+ENABLE_CUDA ?= $(shell test -e $(CUDA_HOME) && echo 1 || echo 0)
 
 .SUFFIXES:
 .SECONDARY:

--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -148,7 +148,7 @@ void moduleToPTX(terra_State * T, llvm::Module * M, int major, int minor, std::s
 static std::string sanitizeName(std::string name) {
     std::string s;
     llvm::raw_string_ostream out(s);
-    for(int i = 0; i < name.size(); i++) {
+    for(size_t i = 0; i < name.size(); i++) {
         char c = name[i];
         if(isalnum(c) || c == '_')
             out << c;
@@ -173,7 +173,7 @@ int terra_toptx(lua_State * L) {
     int minor = version % 10;
 
     int N = lua_objlen(L,annotations);
-    for(size_t i = 0; i < N; i++) {
+    for(int i = 0; i < N; i++) {
         lua_rawgeti(L,annotations,i+1); // {kernel,annotation,value}
         lua_rawgeti(L,-1,1); //kernel name
         lua_rawgeti(L,-2,2); // annotation name
@@ -190,7 +190,7 @@ int terra_toptx(lua_State * L) {
     //sanitize names
     for(llvm::Module::iterator it = M->begin(), end = M->end(); it != end; ++it) {
         const char * prefix = "cudart:";
-        int prefixsize = strlen(prefix);
+        size_t prefixsize = strlen(prefix);
         std::string name = it->getName();
         if(name.size() >= prefixsize && name.substr(0,prefixsize) == prefix) {
             std::string shortname = name.substr(prefixsize);

--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -55,7 +55,7 @@ static const char * libnvvm = "/nvvm/lib/libnvvm.dylib";
 
 struct terra_CUDAState {
     int initialized;
-    #define INIT_SYM(x) decltype(&x) x;
+    #define INIT_SYM(x) decltype(&::x) x;
     CUDA_SYM(INIT_SYM)
     #undef INIT_SYM    
 };


### PR DESCRIPTION
1) It's common for CUDA_HOME to be something other than /usr/local/cuda, but the ENABLE_CUDA check was hardcoded.
2) g++ gets confused about which symbol's type you're trying to grab in tcuda.cpp - an explicit global namespace cleans it up.

Both changes work ok on my mac laptop too.