### PR TITLE
Allow LuaJIT to be configured by the user.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,12 @@ FLAGS = -Wall -g -fPIC
 LFLAGS = -g
 
 #luajit will be downloaded automatically (it's much smaller than llvm)
-LUAJIT_VERSION=LuaJIT-2.0.4
-LUAJIT_URL=http://luajit.org/download/$(LUAJIT_VERSION).tar.gz
-LUAJIT_TAR=$(LUAJIT_VERSION).tar.gz
-LUAJIT_DIR=build/$(LUAJIT_VERSION)
+LUAJIT_VERSION ?= LuaJIT-2.0.4
+LUAJIT_URL ?= http://luajit.org/download/$(LUAJIT_VERSION).tar.gz
+LUAJIT_TAR ?= $(LUAJIT_VERSION).tar.gz
+LUAJIT_DIR ?= build/$(LUAJIT_VERSION)
 
-LUAJIT_LIB=build/$(LUAJIT_VERSION)/src/libluajit.a
+LUAJIT_LIB ?= build/$(LUAJIT_VERSION)/src/libluajit.a
 
 FLAGS += -I build -I release/include/terra -I $(LUAJIT_DIR)/src -I $(shell $(LLVM_CONFIG) --includedir) -I $(CLANG_PREFIX)/include
 


### PR DESCRIPTION
This is so that I can host a custom LuaJIT mirror to work around luajit.org unavailability, etc.