### PR TITLE
several fixes for nontemporal loads and stores

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2055,6 +2055,14 @@ if(baseT->isIntegerTy()) { \
                     int alignment = attr.number("alignment");
                     l->setAlignment(alignment);
                 }
+                if(attr.boolean("nontemporal")) {
+                    #if LLVM_VERSION <= 35
+                    auto list = ConstantInt::get(Type::getInt32Ty(*CU->TT->ctx), 1);
+                    #else
+                    auto list = ConstantAsMetadata::get(ConstantInt::get(Type::getInt32Ty(*CU->TT->ctx), 1));
+                    #endif
+                    l->setMetadata("nontemporal", MDNode::get(*CU->TT->ctx, list));
+                }
                 l->setVolatile(attr.boolean("isvolatile"));
                 return l;
             } break;

--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -865,6 +865,8 @@ function T.quote:asvalue()
             end
             return t
         elseif e:is "var" then return e.symbol
+        elseif e:is "luaobject" then
+             return e.value
         else
             local runconstantprop = function()
                 return terra.constant(self):get()
@@ -3494,7 +3496,7 @@ end)
 local function createattributetable(q)
     local attr = q:asvalue()
     if type(attr) ~= "table" then
-        error("attributes must be a table")
+        error("attributes must be a table, not a " .. type(attr))
     end
     return T.attr(attr.nontemporal and true or false, 
                   type(attr.align) == "number" and attr.align or nil,

--- a/tests/nontemporal.t
+++ b/tests/nontemporal.t
@@ -1,7 +1,18 @@
 
 
 terra foobar(a : &vector(float,4),b : vector(int,4))
-	terralib.attrstore(a,b,{ nontemporal = true })
+        var x = terralib.attrload(a,{ nontemporal = true })
+	terralib.attrstore(a,b+x,{ nontemporal = true })
+end
+
+function wrap(attrs)
+    local fn = terra (a : &vector(float,4),b : vector(int,4))
+        var x = terralib.attrload(a,attrs)
+	terralib.attrstore(a,b+x,attrs)
+    end
+    return fn
 end
 
 foobar:disas()
+wrap({ nontemporal = true }):disas()
+wrap({ nontemporal = false }):disas()


### PR DESCRIPTION
Three fixes:
1) Generate !nontemporal metadata for loads as well.  (This is allowed in the LLVM IR, although the x86 code generators seem to ignore it for now.)
2) Do not generate the !nontemporal metadata if the "nontemporal" attribute is false.
3) Allow the attributes for attrload/attrstore to be provided via a variable holding a lua table in addition to the "immediate" constructor syntax.
