### PR TITLE
Add failing hex formatted number test.

### DIFF
--- a/tests/hexf.t
+++ b/tests/hexf.t
@@ -7,3 +7,15 @@ terra foo()
 end
 
 assert(foo() == 15)
+
+terra u32() : uint32
+	return 0xffffffff
+end
+
+assert(u32() == math.pow(2, 32) - 1)
+
+terra u64() : uin64
+	return 0xfffffffffffffffff
+end
+
+assert(u64() == math.pow(2, 64) - 1)


### PR DESCRIPTION
Fails with:
tests/hexf.t:18: malformed number near '0xfffffffffffffffff'