### PR TITLE
add entrymissing must be macro

### DIFF
--- a/api.md
+++ b/api.md
@@ -681,7 +681,7 @@ When a method is called `myobj:mymethod(arg0,...,argN)` and `__getmethod` is not
 
     __entrymissing(entryname,myobj)
     
-If `myobj` does not contain the filed `entryname`, then `__entrymissing` will be called whenever the typechecker sees the expression `myobj.entryname`. It should return a Terra [quote](#quote) to use in place of the field.
+If `myobj` does not contain the filed `entryname`, then `__entrymissing` will be called whenever the typechecker sees the expression `myobj.entryname`. It must be a macro and should return a Terra [quote](#quote) to use in place of the field.
 
 Custom operators:
 


### PR DESCRIPTION
I was just trying out the entrymissing capability for the first time and at first I tried using a lua function rather than a macro, reading the terra source showed me that it had to be a macro, but maybe worth having in the api reference.