### PR TITLE
Add missing depth arg to finishandabortiferrors call

### DIFF
--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -1120,7 +1120,7 @@ function terra.anonfunction(tree,envfn)
     local env = envfn()
     local diag = terra.newdiagnostics()
     tree = evalformalparameters(diag,env,tree)
-    diag:finishandabortiferrors("Errors during function declaration.")
+    diag:finishandabortiferrors("Errors during function declaration.",2)
     tree = typecheck(tree,env)
     tree.name = "anon ("..tree.filename..":"..tree.linenumber..")"
     return T.terrafunction(tree,tree.name,tree.type,tree)


### PR DESCRIPTION
Fixes a problem in error reporting:

```
src/terralib.lua:388: attempt to perform arithmetic on local 'depth' (a nil value)
stack traceback:
	src/terralib.lua:388: in function 'finishandabortiferrors'
	src/terralib.lua:1113: in function <src/terralib.lua:1109>
```