### PR TITLE
debug.traceback does not handle coroutines

### DIFF
--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -399,14 +399,14 @@ end
 
 local TRACEBACK_LEVELS1 = 12
 local TRACEBACK_LEVELS2 = 10
-local function findfirstnilstackframe() --because stack size is not exposed we binary search for it
+local function findfirstnilstackframe(thread) --because stack size is not exposed we binary search for it
     local low,high = 1,1
-    while debug.getinfo(high,"") ~= nil do
+    while debug.getinfo(thread,high,"") ~= nil do
         low,high = high,high*2
     end --invariant: low is non-nil frame, high is nil frame, range gets smaller each iteration
     while low + 1 ~= high do
         local m = math.floor((low+high)/2)
-        if debug.getinfo(m,"") ~= nil then
+        if debug.getinfo(thread,m,"") ~= nil then
             low = m
         else
             high = m
@@ -428,7 +428,12 @@ local function invokeuserfunction(anchor, what, speculate, userfn,  ...)
 end
 terra.fulltrace = false
 -- override the lua traceback function to be aware of Terra compilation contexts
-function debug.traceback(msg,level)
+function debug.traceback(thread,msg,level)
+    if type(thread) ~= 'thread' then
+      level = msg
+      msg = thread
+      thread = coroutine.running()
+    end
     level = level or 1
     level = level + 1 -- don't count ourselves
     local lim = terra.fulltrace and math.huge or TRACEBACK_LEVELS1 + 1
@@ -442,11 +447,11 @@ function debug.traceback(msg,level)
     end
     lines:insert("stack traceback:")
     while true do
-        local di = debug.getinfo(level,"Snlf")
+        local di = debug.getinfo(thread,level,"Snlf")
         if not di then break end
         if di.func == invokeuserfunction then
-            local anchorname,anchor = debug.getlocal(level,1)
-            local whatname,what = debug.getlocal(level,2)
+            local anchorname,anchor = debug.getlocal(thread,level,1)
+            local whatname,what = debug.getlocal(thread,level,2)
             assert(anchorname == "anchor" and whatname == "what")
             lines:insert("\n\t")
             lines:insert(formaterror(anchor,"Errors reported during "..what):sub(1,-2)) 
@@ -474,9 +479,9 @@ function debug.traceback(msg,level)
         end
         level = level + 1
         if level == lim then
-            if debug.getinfo(level + TRACEBACK_LEVELS2,"") ~= nil then
+            if debug.getinfo(thread,level + TRACEBACK_LEVELS2,"") ~= nil then
                 lines:insert("\n\t...")
-                level = findfirstnilstackframe() - TRACEBACK_LEVELS2
+                level = findfirstnilstackframe(thread) - TRACEBACK_LEVELS2
             end
             lim = math.huge
         end


### PR DESCRIPTION
NOTE: Pull request is broken. Only providing the patch for discussion.

See https://www.lua.org/manual/5.1/manual.html#pdf-debug.traceback - The override of debug.traceback in terralib does not respect the thread parameter.

You get something like this:

```
$ terra

Terra -- A low-level counterpart to Lua

Stanford University
zdevito@stanford.edu

> = debug.traceback(coroutine.running(), 'on noez!', 2)
src/terralib.lua:433: attempt to perform arithmetic on local 'level' (a string value)
stack traceback:
	src/terralib.lua:433: in function <src/terralib.lua:431>

```

Compare to Lua:

```
~/Projects/plop $ lua
Lua 5.2.4  Copyright (C) 1994-2015 Lua.org, PUC-Rio
> = debug.traceback(coroutine.running(), 'on noez!', 2)
on noez!
stack traceback:
	[C]: in ?
> ^D
```

I tried to fix the definition of debug.traceback in terralib, but the obvious solution produced 'error in error handling' for some non-obvious reason. I'll take another look at it soon if you don't have an idea offhand.