### PR TITLE
Modified golike.t to work with terralib.saveobj

### DIFF
--- a/tests/class2.t
+++ b/tests/class2.t
@@ -1,3 +1,4 @@
+local S = require("std")
 local Interface = require("lib/golike")
 
 local I = Interface.create {
@@ -43,3 +44,7 @@ end
 
 local test = require("test")
 test.eq(foo(),9)
+
+terralib.saveobj("class2", "executable", {
+	main = terra() S.printf("foo() = %d\n", foo()) end,
+})


### PR DESCRIPTION
This PR introduces modified golike.t, which now uses constant expressions for vtables. This has two benefits --- (1) golike.t based code can now be saved to object file and (2) more room for compiler optimizations.
