### PR TITLE
Fix to print errors to stderr, instead of stdout

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@
 #include "terra.h"
 
 static void doerror(lua_State * L) {
-    printf("%s\n",luaL_checkstring(L,-1));
+    fprintf(stderr,"%s\n",luaL_checkstring(L,-1));
     lua_close(L);
     terra_llvmshutdown();
     exit(1);


### PR DESCRIPTION
Problem:
- the doerror() function in main.cpp prints errors to stdout and
this interferes when scripting with terra
- when using terra combined with unix piping stdout and stderr get
mixed into stdout and this might cause problems to downstream
commands in the linux pipeline that aren't expecting error messages
in their stdin stream

Solution:
- change error-printing stream to stderr