### PR TITLE
Updated Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 -include Makefile.inc
 
 # Debian packages name llvm-config with a version number - list them here in preference order
-LLVM_CONFIG ?= $(shell which llvm-config-3.5 llvm-config | head -1)
+LLVM_CONFIG ?= $(shell which llvm-config-3.7 llvm-config | head -1)
 #luajit will be downloaded automatically (it's much smaller than llvm)
 #to override this, set LUAJIT_PREFIX to the home of an already installed luajit
 LUAJIT_PREFIX ?= build


### PR DESCRIPTION
Updated llvm-config-3.5 to llvm-config-3.7

LLVM_CONFIG ?= $(shell which llvm-config-3.7 llvm-config | head -1)


3.7 seem to be the oldest llvm library in brew. I tested this with a formula I created.

Sample Brew Formula: 

class Terra < Formula
  desc "Low-level system programming language in the Lua programming language."
  homepage "http://terralang.org"
  url "https://github.com/roachmd/terra/archive/release-2017-08-25.tar.gz"
  sha256 "029103538a8472ef5471b3bf17bcb2c872a9dff024d94b1f1184ab674bcedc78"
  head "https://github.com/zdevito/terra.git"

  depends_on "llvm@3.7" => :recommended

  def install
    system "make"
    bin.install Dir["release/*"]
  end

  test do
    cd " tests"
    system "#{bin}/terra", "run"
  end