### PR TITLE
eliminate compiler warnings in build

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -652,12 +652,16 @@ static void Name_print(Name * name, LexState * ls) {
 
 static void print_captured_locals(LexState * ls, TerraCnt * tc);
 
+/* print_stack not used anywhere right now - comment out to eliminate
+   compiler warning */
+#if 0
 static void print_stack(lua_State * L, int idx) {
     lua_pushvalue(L,idx);
     lua_getfield(L,LUA_GLOBALSINDEX,"print");
     lua_insert(L,-2);
     lua_call(L,1,0);
 }
+#endif
 
 //store the lua object on the top of the stack to to the _G.terra._trees table, returning its index in the table
 static int store_value(LexState * ls) {

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2376,7 +2376,7 @@ if(baseT->isIntegerTy()) { \
             case T_label: {
                 int depth;
                 BasicBlock * bb = getOrCreateBlockForLabel(stmt,&depth);
-                assert(depth == deferred.size());
+                assert((size_t)depth == deferred.size());
                 B->CreateBr(bb);
                 followsBB(bb);
                 setInsertBlock(bb);
@@ -2384,7 +2384,7 @@ if(baseT->isIntegerTy()) { \
             case T_gotostat: {
                 int depth;
                 BasicBlock * bb = getOrCreateBlockForLabel(stmt,&depth);
-                assert(deferred.size() >= depth);
+                assert(deferred.size() >= (size_t)depth);
                 emitDeferred(deferred.size() - depth);
                 B->CreateBr(bb);
                 startDeadCode();

--- a/src/tdebug.cpp
+++ b/src/tdebug.cpp
@@ -21,9 +21,11 @@
 
 using namespace llvm;
 
+#ifdef DEBUG_INFO_WORKING
 static bool pointisbeforeinstruction(uintptr_t point, uintptr_t inst, bool isNextInst) {
     return point < inst || (!isNextInst && point == inst);
 }
+#endif
 static bool stacktrace_findline(terra_CompilerState * C, const TerraFunctionInfo * fi, uintptr_t ip, bool isNextInstr, StringRef * file, size_t * lineno) {
     #ifdef DEBUG_INFO_WORKING
     const std::vector<JITEvent_EmittedFunctionDetails::LineStart> & LineStarts = fi->efd.LineStarts;


### PR DESCRIPTION
Eliminates a few compiler warnings that have been bugging me for a while.  No functional changes.