### PR TITLE
attempt at adding support for FreeBSD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /build
 /release/bin
 /release/lib
+/release/include/terra/lauxlib.h
+/release/include/terra/lua*.h
 /terra
 /tests/afile.txt
 /tests/benchmark_fannkuchredux
@@ -10,6 +12,8 @@
 /tests/output2
 /tests/renamed
 /tests/speed
+/tests/dynlib
+/tests/dynlib.exe
 
 *.bc
 *.ll

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ CPPFLAGS += -std=c++11
 endif
 
 
-ifeq ($(UNAME), Linux)
+ifneq ($(findstring $(UNAME), Linux FreeBSD),)
 DYNFLAGS = -shared -fPIC
 TERRA_STATIC_LIBRARY += -Wl,-export-dynamic -Wl,--whole-archive $(LIBRARY) -Wl,--no-whole-archive
 else
@@ -105,7 +105,7 @@ endif
 LLVM_LIBS += $(shell $(LLVM_CONFIG) --libs)
 ifneq ($(REEXPORT_LLVM_COMPONENTS),)
   REEXPORT_LIBS := $(shell $(LLVM_CONFIG) --libs $(REEXPORT_LLVM_COMPONENTS))
-  ifeq ($(UNAME), Linux)
+  ifneq ($(findstring $(UNAME), Linux FreeBSD),)
     LLVM_LIBRARY_FLAGS += -Wl,--whole-archive $(REEXPORT_LIBS) -Wl,--no-whole-archive
   else
     LLVM_LIBRARY_FLAGS += $(REEXPORT_LIBS:%=-Wl,-force_load,%)
@@ -125,6 +125,9 @@ endif
 
 ifeq ($(UNAME), Linux)
 SUPPORT_LIBRARY_FLAGS += -ldl -pthread
+endif
+ifeq ($(UNAME), FreeBSD)
+SUPPORT_LIBRARY_FLAGS += -lexecinfo -pthread
 endif
 
 PACKAGE_DEPS += $(LUAJIT_LIB)
@@ -192,7 +195,7 @@ endif
 
 build/lib/libluajit-5.1.a: build/$(LUAJIT_TAR)
 	(cd build; tar -xf $(LUAJIT_TAR))
-	(cd $(LUAJIT_DIR); make install PREFIX=$(realpath build) CC=$(CC) STATIC_CC="$(CC) -fPIC")
+	(cd $(LUAJIT_DIR); $(MAKE) install PREFIX=$(realpath build) CC=$(CC) STATIC_CC="$(CC) -fPIC")
 
 release/include/terra/%.h:  $(LUAJIT_INCLUDE)/%.h $(LUAJIT_LIB) 
 	cp $(LUAJIT_INCLUDE)/$*.h $@

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -348,9 +348,13 @@ static void InitializeJIT(TerraCompilationUnit * CU) {
 #endif
     
     std::string err;
+    std::vector<std::string> mattrs;
+    if(!CU->TT->Features.empty())
+      mattrs.push_back(CU->TT->Features);
     EngineBuilder eb(UNIQUEIFY(Module,topeemodule));
     eb.setErrorStr(&err)
       .setMCPU(CU->TT->CPU)
+      .setMAttrs(mattrs)
       .setEngineKind(EngineKind::JIT)
 #ifdef TERRA_CAN_USE_OLD_JIT
       .setAllocateGVsWithCode(false)

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -273,7 +273,11 @@ int terra_inittarget(lua_State * L) {
     if(!lua_isnil(L, 3))
         TT->Features = lua_tostring(L,3);
     else
+#ifdef DISABLE_AVX
+        TT->Features = "-avx";
+#else
         TT->Features = HostHasAVX() ? "+avx" : "";
+#endif
     
     TargetOptions options;
     DEBUG_ONLY(T) {

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -84,7 +84,7 @@ struct DisassembleFunctionListener : public JITEventListener {
 #if LLVM_VERSION >= 34
     void InitializeDebugData(StringRef name, object::SymbolRef::Type type, uint64_t sz) {
         if(type == object::SymbolRef::ST_Function) {
-            #if !defined(__arm__) && !defined(__linux__)
+            #if !defined(__arm__) && !defined(__linux__) && !defined(__FreeBSD__)
             name = name.substr(1);
             #endif
             void * addr = (void*) CU->ee->getFunctionAddress(name);
@@ -2840,7 +2840,9 @@ static bool SaveSharedObject(TerraCompilationUnit * CU, Module * M, std::vector<
 	cmd.push_back("-g");
     cmd.push_back("-shared");
     cmd.push_back("-Wl,-export-dynamic");
+#ifndef __FreeBSD__
     cmd.push_back("-ldl");
+#endif
 	cmd.push_back("-fPIC");
 #endif
 

--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -938,6 +938,10 @@ int include_c(lua_State * L) {
     args.push_back(TT->Triple.c_str());
     args.push_back("-target-cpu");
     args.push_back(TT->CPU.c_str());
+    if(!TT->Features.empty()) {
+      args.push_back("-target-feature");
+      args.push_back(TT->Features.c_str());
+    }
 
 #ifdef _WIN32
     args.push_back("-fms-extensions");

--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -441,7 +441,7 @@ public:
         AsmLabelAttr * asmlabel = f->getAttr<AsmLabelAttr>();
         if(asmlabel) {
             InternalName = asmlabel->getLabel();
-            #ifndef __linux__
+            #if !defined(__linux__) && !defined(__FreeBSD__)
                 //In OSX and Windows LLVM mangles assembler labels by adding a '\01' prefix
                 InternalName.insert(InternalName.begin(), '\01');
             #endif

--- a/src/tdebug.cpp
+++ b/src/tdebug.cpp
@@ -154,8 +154,13 @@ static void printstacktrace(void * uap, void * data) {
         rip = (void*) uc->uc_mcontext.gregs[REG_RIP];
         rbp = (void*) uc->uc_mcontext.gregs[REG_RBP];
 #else
+#ifdef __FreeBSD__
+        rip = (void*)uc->uc_mcontext.mc_rip;
+        rbp = (void*)uc->uc_mcontext.mc_rbp;
+#else
         rip = (void*)uc->uc_mcontext->__ss.__rip;
         rbp = (void*)uc->uc_mcontext->__ss.__rbp;
+#endif
 #endif
     }
 #else

--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -4016,16 +4016,19 @@ terra.cudahome = os.getenv("CUDA_HOME") or (ffi.os == "Windows" and os.getenv("C
 terra.cudalibpaths = ({ OSX = {driver = "/usr/local/cuda/lib/libcuda.dylib", runtime = "$CUDA_HOME/lib/libcudart.dylib", nvvm =  "$CUDA_HOME/nvvm/lib/libnvvm.dylib"}; 
                        Linux =  {driver = "libcuda.so", runtime = "$CUDA_HOME/lib64/libcudart.so", nvvm = "$CUDA_HOME/nvvm/lib64/libnvvm.so"}; 
                        Windows = {driver = "nvcuda.dll", runtime = "$CUDA_HOME\\bin\\cudart64_*.dll", nvvm = "$CUDA_HOME\\nvvm\\bin\\nvvm64_*.dll"}; })[ffi.os]
-for name,path in pairs(terra.cudalibpaths) do
-	path = path:gsub("%$CUDA_HOME",terra.cudahome)
-	if path:match("%*") and ffi.os == "Windows" then
-		local F = io.popen(('dir /b /s "%s" 2> nul'):format(path))
-		if F then
-			path = F:read("*line") or path
-			F:close()
+-- OS's that are not supported by CUDA will have an undefined value here
+if terra.cudalibpaths then
+	for name,path in pairs(terra.cudalibpaths) do
+		path = path:gsub("%$CUDA_HOME",terra.cudahome)
+		if path:match("%*") and ffi.os == "Windows" then
+			local F = io.popen(('dir /b /s "%s" 2> nul'):format(path))
+			if F then
+				path = F:read("*line") or path
+				F:close()
+			end
 		end
+		terra.cudalibpaths[name] = path
 	end
-	terra.cudalibpaths[name] = path
 end                       
 
 terra.systemincludes = List()

--- a/tests/stattest.t
+++ b/tests/stattest.t
@@ -1,5 +1,10 @@
+-- WARNING: any changes to this file need to change this constant to match!
+local stattest_t_file_size = 480
+
 local ffi = require("ffi")
-if ffi.os == "Windows" then
+-- Windows doesn't have stat() and FreeBSD's version of struct stat uses
+--  bit fields, which terra doesn't seem to handle
+if ffi.os == "Windows" or ffi.os == "BSD" then
   return
 end
 
@@ -10,4 +15,4 @@ terra dostat()
 	return s.st_size
 end
 
-assert(dostat() == 210)
+assert(dostat() == stattest_t_file_size)


### PR DESCRIPTION
The first change allows terra to build and run, at least in the FreeBSD virtual machine I'm using.
I built with clang 3.8, and gmake is required (the BSD version of make does not like the Makefiles at all).
There is no CUDA for FreeBSD, so this is CPU only.  One test (stattest.t) is disabled because FreeBSD's
sys/stat.h uses bit fields in `struct stat`, which confuses terra.

The second two changes address an issue that may or may not be specific to my VM.  Despite the OS
claiming that the CPU supports AVX instructions, I get a SIGILL in many tests because llvm happily
generates AVX instructions.  The workaround involves a general-purpose change that is needed to actually get feature flags into MCJIT and clang (for include_c), followed by a ifdef-protected change
that makes "-avx" the default feature flag if `-DDISABLE_AVX` is set via the `FLAGS` make variable.