### PR TITLE
Handle libdevice properly on CUDA 9.0+

### DIFF
--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -782,6 +782,7 @@ end
 function compilationunit:dump() terra.dumpmodule(self.llvm_cu) end
 
 terra.nativetarget = terra.newtarget {}
+terra.cudatarget = terra.newtarget {Triple = 'nvptx64-nvidia-cuda', FloatABIHard = true}
 terra.jitcompilationunit = terra.newcompilationunit(terra.nativetarget,true) -- compilation unit used for JIT compilation, will eventually specify the native architecture
 
 terra.llvm_gcdebugmetatable = { __gc = function(obj)


### PR DESCRIPTION
When `saveobj`-ing a CUDA module, Terra will now automatically find libdevice (an LLVM bitcode library that contains math functions for GPUs) and link it in. Because we now set the correct target for CUDA modules, LLVM knows to run the appropriate passes (in particular NVVMReflect, which will desugar the `__nvvm_reflect` pseudo-instruction, which is used in libdevice for CUDA versions 9.0 and up).

The user (still) needs to manually `linkllvm` libdevice, if they want to run CUDA code on the terra process.