### PR TITLE
Working LLVM 6.0 support, without CUDA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ before_install:
       sudo apt-get install wget
       if [[ "$LLVM_CONFIG" = "llvm-config-6.0" ]]; then
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo apt-add-repository -y "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
-        sudo apt-get update -qq
-        sudo apt-get install -qq llvm-6.0-dev clang-6.0 libclang-6.0-dev llvm-6.0-dev
+        sudo apt-add-repository -y "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
+        sudo apt-get update -y
+        sudo apt-get install -y llvm-6.0-dev clang-6.0 libclang-6.0-dev llvm-6.0-dev
       else
         sudo apt-get install -qq clang-3.5 libclang-3.5-dev llvm-3.8-dev clang-3.8 libclang-3.8-dev llvm-3.8-dev
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 matrix:
   include:
     - os: linux
-      dist: bionic
+      dist: trusty
       compiler: gcc
       env:
         - LLVM_CONFIG=llvm-config-6.0 CLANG=clang-6.0
@@ -31,7 +31,11 @@ before_install:
   - |
     if [[ "$(uname)" = "Linux" ]]; then
       sudo apt-get update -qq
-      if [[ "$(lsb_release -sc)" = "bionic" ]]; then
+      sudo apt-get install wget
+      if [[ "$LLVM_CONFIG" = "llvm-config-6.0" ]]; then
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo apt-add-repository -y "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
+        sudo apt-get update -qq
         sudo apt-get install -qq llvm-6.0-dev clang-6.0 libclang-6.0-dev llvm-6.0-dev
       else
         sudo apt-get install -qq clang-3.5 libclang-3.5-dev llvm-3.8-dev clang-3.8 libclang-3.8-dev llvm-3.8-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
       if [[ "$LLVM_CONFIG" = "llvm-config-6.0" ]]; then
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo apt-add-repository -y "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         sudo apt-get update -y
         sudo apt-get install -y llvm-6.0-dev clang-6.0 libclang-6.0-dev llvm-6.0-dev
       else

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,9 @@ env:
   matrix:
   - LLVM_CONFIG=llvm-config-3.8 CLANG=clang-3.8
   - LLVM_CONFIG=llvm-config-3.5 CLANG=clang-3.5
+  - LLVM_CONFIG=llvm-config-6.0 CLANG=clang-6.0
 
 matrix:
-  include:
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      env:
-        - LLVM_CONFIG=llvm-config-6.0 CLANG=clang-6.0
   exclude:
     - os: osx
       compiler: gcc
@@ -52,6 +47,12 @@ before_install:
       tar xf clang+llvm-3.5.2-x86_64-apple-darwin.tar.xz
       ln -s clang+llvm-3.5.2-x86_64-apple-darwin/bin/llvm-config llvm-config-3.5
       ln -s clang+llvm-3.5.2-x86_64-apple-darwin/bin/clang clang-3.5
+
+      curl -O http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz
+      tar xf clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz
+      ln -s clang+llvm-6.0.0-x86_64-apple-darwin/bin/llvm-config llvm-config-6.0
+      ln -s clang+llvm-6.0.0-x86_64-apple-darwin/bin/clang clang-6.0
+
       export PATH=$PWD:$PATH
     fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ env:
   - LLVM_CONFIG=llvm-config-3.5 CLANG=clang-3.5
 
 matrix:
+  include:
+    - os: linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - LLVM_CONFIG=llvm-config-6.0 CLANG=clang-6.0
   exclude:
     - os: osx
       compiler: gcc
@@ -25,7 +31,11 @@ before_install:
   - |
     if [[ "$(uname)" = "Linux" ]]; then
       sudo apt-get update -qq
-      sudo apt-get install -qq clang-3.5 libclang-3.5-dev llvm-3.8-dev clang-3.8 libclang-3.8-dev llvm-3.8-dev
+      if [[ "$(lsb_release -sc)" = "bionic" ]]; then
+        sudo apt-get install -qq llvm-6.0-dev clang-6.0 libclang-6.0-dev llvm-6.0-dev
+      else
+        sudo apt-get install -qq clang-3.5 libclang-3.5-dev llvm-3.8-dev clang-3.8 libclang-3.8-dev llvm-3.8-dev
+      fi
     fi
   - |
     if [[ "$(uname)" = "Darwin" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ CPPFLAGS = -fno-rtti -Woverloaded-virtual -fvisibility-inlines-hidden
 
 LLVM_VERSION_NUM=$(shell $(LLVM_CONFIG) --version | sed -e s/svn//)
 LLVM_VERSION=$(shell echo $(LLVM_VERSION_NUM) | $(SED_E) 's/^([0-9]+)\.([0-9]+).*/\1\2/')
-LLVMVERGT4 := $(shell expr $(LLVM_VERSION) \>= 4)
+LLVMVERGT4 := $(shell expr $(LLVM_VERSION) \>= 40)
 
 FLAGS += -DLLVM_VERSION=$(LLVM_VERSION)
 ifneq ($(LLVM_VERSION), 32)

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ CPPFLAGS = -fno-rtti -Woverloaded-virtual -fvisibility-inlines-hidden
 
 LLVM_VERSION_NUM=$(shell $(LLVM_CONFIG) --version | sed -e s/svn//)
 LLVM_VERSION=$(shell echo $(LLVM_VERSION_NUM) | $(SED_E) 's/^([0-9]+)\.([0-9]+).*/\1\2/')
+LLVMVERGT4 := $(shell expr $(LLVM_VERSION) \>= 4)
 
 FLAGS += -DLLVM_VERSION=$(LLVM_VERSION)
 ifneq ($(LLVM_VERSION), 32)
@@ -102,7 +103,11 @@ endif
 #  but this can be a problem if third-party-libraries that also need LLVM are
 #  used - allow the user to request that some/all of the LLVM components be
 #  included and re-exported in their entirety
-LLVM_LIBS += $(shell $(LLVM_CONFIG) --libs)
+ifeq "$(LLVMVERGT4)" "1"
+    LLVM_LIBS += $(shell $(LLVM_CONFIG) --libs --link-static)
+else
+	LLVM_LIBS += $(shell $(LLVM_CONFIG) --libs)
+endif
 ifneq ($(REEXPORT_LLVM_COMPONENTS),)
   REEXPORT_LIBS := $(shell $(LLVM_CONFIG) --libs $(REEXPORT_LLVM_COMPONENTS))
   ifneq ($(findstring $(UNAME), Linux FreeBSD),)

--- a/src/llvmheaders.h
+++ b/src/llvmheaders.h
@@ -67,7 +67,7 @@
 #elif LLVM_VERSION == 60
 #include "llvmheaders_60.h"
 #else
-//#error "unsupported LLVM version"
+#error "unsupported LLVM version"
 //for OSX code completion
 #define LLVM_VERSION 60
 #include "llvmheaders_60.h"

--- a/src/llvmheaders.h
+++ b/src/llvmheaders.h
@@ -37,7 +37,14 @@
 #include "llvm/ExecutionEngine/JITEventListener.h"
 #include "llvm/ExecutionEngine/SectionMemoryManager.h"
 #include "llvm/Support/DynamicLibrary.h"
+
+#if LLVM_VERSION > 40
+#include "llvm/Bitcode/BitcodeReader.h"
+#include "llvm/Bitcode/BitcodeWriter.h"
+#else
 #include "llvm/Bitcode/ReaderWriter.h"
+#endif
+
 #include "llvm/Object/ObjectFile.h"
 #include "llvm-c/Linker.h"
 
@@ -57,11 +64,13 @@
 #include "llvmheaders_38.h"
 #elif LLVM_VERSION == 39
 #include "llvmheaders_39.h"
+#elif LLVM_VERSION == 60
+#include "llvmheaders_60.h"
 #else
-#error "unsupported LLVM version"
+//#error "unsupported LLVM version"
 //for OSX code completion
-#define LLVM_VERSION 39
-#include "llvmheaders_39.h"
+#define LLVM_VERSION 60
+#include "llvmheaders_60.h"
 #endif
 
 #if LLVM_VERSION >= 34

--- a/src/llvmheaders_60.h
+++ b/src/llvmheaders_60.h
@@ -1,0 +1,32 @@
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/Analysis/CallGraphSCCPass.h"
+#include "llvm/Analysis/CallGraph.h"
+#include "llvm/IR/DIBuilder.h"
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/Mangler.h"
+//#include "llvm/ExecutionEngine/ObjectImage.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/Linker/Linker.h"
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/CodeGen/TargetSubtargetInfo.h"
+
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "clang/Rewrite/Frontend/Rewriters.h"
+#include "llvm/IR/DiagnosticPrinter.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/Object/SymbolSize.h"
+
+#define LLVM_PATH_TYPE std::string
+#define RAW_FD_OSTREAM_NONE sys::fs::F_None
+#define RAW_FD_OSTREAM_BINARY sys::fs::F_None
+#define HASFNATTR(attr) getAttributes().hasAttribute(AttributeSet::FunctionIndex, Attribute :: attr)
+#define ADDFNATTR(attr) addFnAttr(Attribute :: attr)
+#define ATTRIBUTE Attributes

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -424,7 +424,6 @@ int terra_compilerinit(struct terra_State * T) {
         return LUA_ERRRUN;
 #endif
     }
-    
     return 0;
 }
 static void freetarget(TerraTarget * TT) {
@@ -3053,30 +3052,27 @@ static int terra_linkllvmimpl(lua_State * L) {
     ErrorOr<Module *> mm = parseBitcodeFile(mb.get().get(),*TT->ctx);
     #endif
     if(!mm) {
-        if(fromstring)
+        if(fromstring) {
             #if LLVM_VERSION >= 50
-            {
                 std::string Msg;
                 raw_string_ostream S((Msg));
                 logAllUnhandledErrors(mm.takeError(), S, "");
                 S.flush();
                 terra_reporterror(T, "linkllvm: %s\n", S.str().c_str());
-            }
             #else
-            terra_reporterror(T, "linkllvm: %s\n", mm.getError().message().c_str());
+                terra_reporterror(T, "linkllvm: %s\n", mm.getError().message().c_str());
             #endif
-	    else
+        } else {
         #if LLVM_VERSION >= 60
-            {
-                std::string Msg;
-                raw_string_ostream S((Msg));
-                logAllUnhandledErrors(mm.takeError(), S, "");
-                S.flush();
-                terra_reporterror(T, "linkllvm(%s): %s\n", filename, S.str().c_str());
-            }
+            std::string Msg;
+            raw_string_ostream S((Msg));
+            logAllUnhandledErrors(mm.takeError(), S, "");
+            S.flush();
+            terra_reporterror(T, "linkllvm(%s): %s\n", filename, S.str().c_str());
         #else
 	        terra_reporterror(T, "linkllvm(%s): %s\n", filename, mm.getError().message().c_str());
         #endif
+        }
     }
     #if LLVM_VERSION >= 37
     Module * M = mm.get().release();

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2722,7 +2722,11 @@ static int terra_llvmsizeof(lua_State * L) {
 static void * GetGlobalValueAddress(TerraCompilationUnit * CU, StringRef Name) {
     if(CU->T->options.debug > 1)
         return sys::DynamicLibrary::SearchForAddressOfSymbol(Name);
+#if LLVM_VERSION < 38
+    return (void*)CU->ee->getGlobalValueAddress(Name);
+#else
     return (void*)CU->ee->getPointerToGlobalIfAvailable(Name);
+#endif
 }
 static bool MCJITShouldCopy(GlobalValue * G, void * data) {
     TerraCompilationUnit * CU = (TerraCompilationUnit*) data;

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1441,6 +1441,8 @@ struct FunctionEmitter {
         VERBOSE_ONLY(T) {
             #if LLVM_VERSION < 38
             fstate->func->dump();
+            #elif LLVM_VERSION == 38
+            fstate->func->print(llvm::errs(), true);
             #else
             fstate->func->print(llvm::errs(), nullptr);
             #endif
@@ -2727,7 +2729,11 @@ static void * GetGlobalValueAddress(TerraCompilationUnit * CU, StringRef Name) {
 #if LLVM_VERSION < 38
     return (void*)CU->ee->getGlobalValueAddress(Name);
 #else
+    #if LLVM_VERSION == 38
+    GlobalVariable * gvar = CU->ee->FindGlobalVariableNamed(Name.str().c_str(), false);
+    #else
     GlobalVariable * gvar = CU->ee->FindGlobalVariableNamed(Name, false);
+    #endif
     //CU->ee->finalizeObject();
     return gvar?(void*)CU->ee->getOrEmitGlobalVariable(gvar):0;
 #endif
@@ -2831,6 +2837,8 @@ static int terra_disassemble(lua_State * L) {
     void * addr = lua_touserdata(L,2); assert(fn);
     #if LLVM_VERSION < 38
     fn->dump();
+    #elif LLVM_VERSION == 38
+    fn->print(llvm::errs(), true);
     #else
     fn->print(llvm::errs(), nullptr);
     #endif

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1364,6 +1364,8 @@ struct FunctionEmitter {
                         VERBOSE_ONLY(T) {
                             #if LLVM_VERSION < 38
                             scc[i]->dump();
+                            #elif LLVM_VERSION == 38
+                            scc[i]->print(llvm::errs(), true);
                             #else
                             scc[i]->print(llvm::errs(), nullptr);
                             #endif
@@ -2725,7 +2727,9 @@ static void * GetGlobalValueAddress(TerraCompilationUnit * CU, StringRef Name) {
 #if LLVM_VERSION < 38
     return (void*)CU->ee->getGlobalValueAddress(Name);
 #else
-    return (void*)CU->ee->getPointerToGlobalIfAvailable(Name);
+    GlobalVariable * gvar = CU->ee->FindGlobalVariableNamed(Name);
+    //CU->ee->finalizeObject();
+    return gvar?(void*)CU->ee->getOrEmitGlobalVariable(gvar):0;
 #endif
 }
 static bool MCJITShouldCopy(GlobalValue * G, void * data) {

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2727,7 +2727,7 @@ static void * GetGlobalValueAddress(TerraCompilationUnit * CU, StringRef Name) {
 #if LLVM_VERSION < 38
     return (void*)CU->ee->getGlobalValueAddress(Name);
 #else
-    GlobalVariable * gvar = CU->ee->FindGlobalVariableNamed(Name);
+    GlobalVariable * gvar = CU->ee->FindGlobalVariableNamed(Name, false);
     //CU->ee->finalizeObject();
     return gvar?(void*)CU->ee->getOrEmitGlobalVariable(gvar):0;
 #endif

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -74,12 +74,15 @@ static llvm_shutdown_obj llvmshutdownobj;
 #if LLVM_VERSION < 38
 #define TERRA_DUMP_FUNCTION(t) (t)->dump()
 #define TERRA_DUMP_TYPE(t) (t)->dump()
+#define TERRA_DUMP_MODULE(t) (t)->dump()
 #elif LLVM_VERSION == 38
 #define TERRA_DUMP_FUNCTION(t) (t)->print(llvm::errs(), true)
 #define TERRA_DUMP_TYPE(t) (t)->print(llvm::errs(), true)
+#define TERRA_DUMP_MODULE(t) (t)->print(llvm::errs(), nullptr)
 #else
 #define TERRA_DUMP_FUNCTION(t) (t)->print(llvm::errs(), nullptr)
 #define TERRA_DUMP_TYPE(t) (t)->print(llvm::errs(), true)
+#define TERRA_DUMP_MODULE(t) (t)->print(llvm::errs(), nullptr)
 #endif
 
 struct DisassembleFunctionListener : public JITEventListener {
@@ -3123,6 +3126,6 @@ static int terra_dumpmodule(lua_State * L) {
     terra_State * T = terra_getstate(L, 1); (void)T;
     TerraCompilationUnit * CU = (TerraCompilationUnit*) terra_tocdatapointer(L,1);
     if(CU)
-        TERRA_DUMP_FUNCTION(CU->M);
+        TERRA_DUMP_MODULE(CU->M);
     return 0;
 }

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -11,10 +11,6 @@ extern "C" {
 #include <stdio.h>
 #include <inttypes.h>
 
-#ifdef TERRA_STACKTRACE
-#include <execinfo.h>
-#endif
-
 #ifdef _WIN32
 #include <io.h>
 #include <time.h>
@@ -402,41 +398,6 @@ static void InitializeJIT(TerraCompilationUnit * CU) {
     CU->ee->RegisterJITEventListener(CU->jiteventlistener);
 }
 
-#ifdef TERRA_STACKTRACE
-static inline void printStackTrace( FILE *out = stderr, unsigned int max_frames = 63 )
-{
-   fprintf(out, "stack trace:\n");
- 
-   // storage array for stack trace address data
-   void* addrlist[max_frames+1];
- 
-   // retrieve current stack addresses
-   size_t addrlen = backtrace( addrlist, sizeof( addrlist ) / sizeof( void* ));
- 
-   if ( addrlen == 0 ) 
-   {
-      fprintf( out, "  \n" );
-      return;
-   }
- 
-   // create readable strings to each frame.
-   char** symbollist = backtrace_symbols( addrlist, addrlen );
- 
-   // print the stack trace.
-   for ( size_t i = 4; i < addrlen; i++ )
-      fprintf( out, "%s\n", symbollist[i]);
- 
-   free(symbollist);
-}
-
-void llvm_fatal_handler(void *user_data, const std::string &reason, bool gen_crash_diag) {
-#ifdef __APPLE__
-    printStackTrace();
-#endif
-    std::abort();
-}
-#endif
-
 int terra_compilerinit(struct terra_State * T) {
     if(!OneTimeInit(T))
         return LUA_ERRRUN;
@@ -463,9 +424,7 @@ int terra_compilerinit(struct terra_State * T) {
         return LUA_ERRRUN;
 #endif
     }
-#ifdef TERRA_STACKTRACE
-    install_fatal_error_handler(llvm_fatal_handler);
-#endif
+    
     return 0;
 }
 static void freetarget(TerraTarget * TT) {

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -692,7 +692,11 @@ class Types {
         st->setBody(entry_types);
         VERBOSE_ONLY(T) {
             printf("Struct Layout Is:\n");
+            #if LLVM_VERSION < 38
+            st->dump();
+            #else
             st->print(llvm::errs(), false);
+            #endif
             printf("\nEnd Layout\n");
         }
     }
@@ -1358,7 +1362,11 @@ struct FunctionEmitter {
                         }
                         CU->fpm->run(*scc[i]);
                         VERBOSE_ONLY(T) {
+                            #if LLVM_VERSION < 38
+                            scc[i]->dump();
+                            #else
                             scc[i]->print(llvm::errs(), nullptr);
+                            #endif
                         }
                     }
                 }
@@ -1429,7 +1437,11 @@ struct FunctionEmitter {
         assert(breakpoints.size() == 0);
         
         VERBOSE_ONLY(T) {
+            #if LLVM_VERSION < 38
+            fstate->func->dump();
+            #else
             fstate->func->print(llvm::errs(), nullptr);
+            #endif
         }
         verifyFunction(*fstate->func);
         
@@ -1995,7 +2007,11 @@ if(baseT->isIntegerTy()) { \
                     Constant * ptrint = ConstantInt::get(CU->getDataLayout().getIntPtrType(*CU->TT->ctx), *(const intptr_t*)data);
                     r = ConstantExpr::getIntToPtr(ptrint, typ->type);
                 } else {
+                    #if LLVM_VERSION < 38
+                    typ->type->dump();
+                    #else
                     typ->type->print(llvm::errs(), false);
+                    #endif
                     assert(!"NYI - constant load\n");
                 }
                 lua_pop(L,1); // remove pointer
@@ -2805,7 +2821,11 @@ static int terra_disassemble(lua_State * L) {
     terra_State * T = terra_getstate(L, 1);
     Function * fn = (Function*) lua_touserdata(L,1); assert(fn);
     void * addr = lua_touserdata(L,2); assert(fn);
+    #if LLVM_VERSION < 38
+    fn->dump();
+    #else
     fn->print(llvm::errs(), nullptr);
+    #endif
     if(T->C->functioninfo.count(addr)) {
         TerraFunctionInfo & fi = T->C->functioninfo[addr];
         printf("assembly for function at address %p\n",addr);
@@ -3113,6 +3133,10 @@ static int terra_dumpmodule(lua_State * L) {
     terra_State * T = terra_getstate(L, 1); (void)T;
     TerraCompilationUnit * CU = (TerraCompilationUnit*) terra_tocdatapointer(L,1);
     if(CU)
+        #if LLVM_VERSION < 38
+        CU->M->dump();
+        #else
         CU->M->print(llvm::errs(), nullptr);
+        #endif
     return 0;
 }

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -306,12 +306,12 @@ int terra_inittarget(lua_State * L) {
         luaL_error(L,"failed to initialize target for LLVM Triple: %s (%s)",TT->Triple.c_str(),err.c_str());
     }
     TT->tm = TheTarget->createTargetMachine(TT->Triple, TT->CPU, TT->Features, options,
-#if defined(_OS_LINUX_) || defined(_OS_FREEBSD_)
+#if defined(__linux__) || defined(__unix__) || (LLVM_VERSION < 50)
         Reloc::PIC_,
 #else
         Optional<Reloc::Model>(),
 #endif
-#if defined(_CPU_PPC_) || defined(_CPU_PPC64_)
+#if defined(__powerpc64__)
         // On PPC the small model is limited to 16bit offsets
         CodeModel::Medium,
 #else

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -11,7 +11,7 @@ extern "C" {
 #include <stdio.h>
 #include <inttypes.h>
 
-#ifndef TERRA_NO_STACKTRACE
+#ifdef TERRA_STACKTRACE
 #include <execinfo.h>
 #endif
 
@@ -390,7 +390,7 @@ static void InitializeJIT(TerraCompilationUnit * CU) {
     CU->ee->RegisterJITEventListener(CU->jiteventlistener);
 }
 
-#ifndef TERRA_NO_STACKTRACE
+#ifdef TERRA_STACKTRACE
 static inline void printStackTrace( FILE *out = stderr, unsigned int max_frames = 63 )
 {
    fprintf(out, "stack trace:\n");
@@ -451,7 +451,7 @@ int terra_compilerinit(struct terra_State * T) {
         return LUA_ERRRUN;
 #endif
     }
-#ifndef TERRA_NO_STACKTRACE
+#ifdef TERRA_STACKTRACE
     install_fatal_error_handler(llvm_fatal_handler);
 #endif
     return 0;

--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -225,7 +225,11 @@ int terra_toptx(lua_State * L) {
     moduleToPTX(T,M,major,minor,&ptx,libdevice);
     if(dumpmodule) {
         fprintf(stderr,"CUDA Module:\n");
+        #if LLVM_VERSION < 38
+        M->dump();
+        #else
         M->print(llvm::errs(), nullptr);
+        #endif        
         fprintf(stderr,"Generated PTX:\n%s\n",ptx.c_str());
     }
     lua_pushstring(L,ptx.c_str());

--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -229,7 +229,7 @@ int terra_toptx(lua_State * L) {
         M->dump();
         #else
         M->print(llvm::errs(), nullptr);
-        #endif        
+        #endif
         fprintf(stderr,"Generated PTX:\n%s\n",ptx.c_str());
     }
     lua_pushstring(L,ptx.c_str());

--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -225,7 +225,7 @@ int terra_toptx(lua_State * L) {
     moduleToPTX(T,M,major,minor,&ptx,libdevice);
     if(dumpmodule) {
         fprintf(stderr,"CUDA Module:\n");
-        M->dump();
+        M->print(llvm::errs(), nullptr);
         fprintf(stderr,"Generated PTX:\n%s\n",ptx.c_str());
     }
     lua_pushstring(L,ptx.c_str());

--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -485,7 +485,9 @@ public:
             0));
         }
         F->setParams(params);
-        #if LLVM_VERSION >= 33
+        #if LLVM_VERSION >= 50
+        CompoundStmt * stmts = CompoundStmt::Create(*Context, outputstmts, SourceLocation(), SourceLocation());
+        #elif LLVM_VERSION >= 33
         CompoundStmt * stmts = new (*Context) CompoundStmt(*Context, outputstmts, SourceLocation(), SourceLocation());
         #else
         CompoundStmt * stmts = new (*Context) CompoundStmt(*Context, &outputstmts[0], outputstmts.size(), SourceLocation(), SourceLocation());
@@ -613,6 +615,7 @@ public:
 #endif
 };
 
+#if LLVM_VERSION < 50
 static llvm::sys::TimeValue ZeroTime() {
 #if LLVM_VERSION >= 36
     return llvm::sys::TimeValue::ZeroTime();
@@ -620,7 +623,11 @@ static llvm::sys::TimeValue ZeroTime() {
     return llvm::sys::TimeValue::ZeroTime;
 #endif
 }
-
+#else
+static llvm::sys::TimePoint<> ZeroTime() {
+    return llvm::sys::TimePoint<>(std::chrono::nanoseconds::zero());
+}
+#endif
 class LuaOverlayFileSystem : public clang::vfs::FileSystem {
 private:
   IntrusiveRefCntPtr<vfs::FileSystem> RFS;

--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -438,6 +438,9 @@ public:
             return true;
         }
         std::string InternalName = FuncName;
+
+        // Avoid mangle on LLVM 6 and macOS
+        #if !((LLVM_VERSION > 50) && __APPLE__)
         AsmLabelAttr * asmlabel = f->getAttr<AsmLabelAttr>();
         if(asmlabel) {
             InternalName = asmlabel->getLabel();
@@ -446,6 +449,8 @@ public:
                 InternalName.insert(InternalName.begin(), '\01');
             #endif
         }
+        #endif
+        
         CreateFunction(FuncName,InternalName,&typ);
         
         KeepLive(f);//make sure this function is live in codegen by creating a dummy reference to it (void) is to suppress unused warnings

--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -440,17 +440,23 @@ public:
         std::string InternalName = FuncName;
 
         // Avoid mangle on LLVM 6 and macOS
-        #if !((LLVM_VERSION > 50) && __APPLE__)
         AsmLabelAttr * asmlabel = f->getAttr<AsmLabelAttr>();
         if(asmlabel) {
+            #if !((LLVM_VERSION > 50) && __APPLE__)
             InternalName = asmlabel->getLabel();
             #if !defined(__linux__) && !defined(__FreeBSD__)
                 //In OSX and Windows LLVM mangles assembler labels by adding a '\01' prefix
                 InternalName.insert(InternalName.begin(), '\01');
             #endif
+            #else
+            std::string label = asmlabel->getLabel();
+            if(!((label[0] == '_') && (label.substr(1) == InternalName))) {
+                InternalName = asmlabel->getLabel();
+                InternalName.insert(InternalName.begin(), '\01');
+            }
+            #endif
         }
-        #endif
-        
+
         CreateFunction(FuncName,InternalName,&typ);
         
         KeepLive(f);//make sure this function is live in codegen by creating a dummy reference to it (void) is to suppress unused warnings

--- a/src/tinline.cpp
+++ b/src/tinline.cpp
@@ -77,7 +77,12 @@ void ManualInliner::run(std::vector<Function *>::iterator fbegin, std::vector<Fu
 #else
     CallGraphSCC SCC(*CG,NULL);
 #endif
+
+#if LLVM_VERSION >= 50
+    SCC.initialize(ArrayRef<CallGraphNode *>(nodes));
+#else
     SCC.initialize(&nodes[0], &nodes[0]+nodes.size());
+#endif
     SI->runOnSCC(SCC);
     //We optimize the function now, which will invalidate the call graph,
     //removing called functions makes sure that further inlining passes don't attempt to add invalid callsites as inlining candidates

--- a/src/tllvmutil.cpp
+++ b/src/tllvmutil.cpp
@@ -370,8 +370,12 @@ void llvmutil_optimizemodule(Module * M, TargetMachine * TM) {
     PassManagerBuilder PMB;
     PMB.OptLevel = 3;
     PMB.SizeLevel = 0;
+#if LLVM_VERSION < 50
+    PMB.Inliner = createFunctionInliningPass(PMB.OptLevel, 0);
+#else
     PMB.Inliner = createFunctionInliningPass(PMB.OptLevel, 0, false);
-    
+#endif
+
 #if LLVM_VERSION >= 35
     PMB.LoopVectorize = true;
     PMB.SLPVectorize = true;

--- a/src/tllvmutil.cpp
+++ b/src/tllvmutil.cpp
@@ -23,8 +23,9 @@
 #if LLVM_VERSION >= 35
 #include "llvm/MC/MCContext.h"
 #endif
+#if LLVM_VERSION < 50
 #include "llvm/Support/MemoryObject.h"
-
+#endif
 #ifndef _WIN32
 #include <sys/wait.h>
 #endif
@@ -86,6 +87,7 @@ void llvmutil_addoptimizationpasses(PassManagerBase * fpm) {
     PMB.populateModulePassManager(W);
 }
 
+#if LLVM_VERSION < 60
 struct SimpleMemoryObject : public MemoryObject {
   uint64_t getBase() const { return 0; }
   uint64_t getExtent() const { return ~0ULL; }
@@ -94,6 +96,7 @@ struct SimpleMemoryObject : public MemoryObject {
     return 0;
   }
 };
+#endif
 
 void llvmutil_disassemblefunction(void * data, size_t numBytes, size_t numInst) {
     InitializeNativeTargetDisassembler();
@@ -367,7 +370,7 @@ void llvmutil_optimizemodule(Module * M, TargetMachine * TM) {
     PassManagerBuilder PMB;
     PMB.OptLevel = 3;
     PMB.SizeLevel = 0;
-    PMB.Inliner = createFunctionInliningPass(PMB.OptLevel, 0);
+    PMB.Inliner = createFunctionInliningPass(PMB.OptLevel, 0, false);
     
 #if LLVM_VERSION >= 35
     PMB.LoopVectorize = true;
@@ -396,7 +399,7 @@ error_code llvmutil_createtemporaryfile(const Twine &Prefix, StringRef Suffix, S
 int llvmutil_executeandwait(LLVM_PATH_TYPE program, const char ** args, std::string * err) {
 #if LLVM_VERSION >= 34
     bool executionFailed = false;
-    llvm::sys::ProcessInfo Info = llvm::sys::ExecuteNoWait(program,args,0,0,0,err,&executionFailed);
+    llvm::sys::ProcessInfo Info = llvm::sys::ExecuteNoWait(program,args,nullptr,{},0,err,&executionFailed);
     if(executionFailed)
         return -1;
     #ifndef _WIN32


### PR DESCRIPTION
This is a preliminary work on supporting newer LLVM JIT. Ultimately I think MCJIT is going to be replaced by Orc, however this PR enables basic functions without too much work.

Tested on my Mac running macOS High Sierra and LLVM 6.0.1.