### PR TITLE
Support CUDA for LLVM 5 and 6 using LLVM's NVPTX backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
       ln -s clang+llvm-3.5.2-x86_64-apple-darwin/bin/clang clang-3.5
       
       curl -O http://releases.llvm.org/5.0.1/clang+llvm-5.0.1-x86_64-apple-darwin.tar.xz
-      tar xf clang+llvm-5.0.1-final-x86_64-apple-darwin.tar.xz
+      tar xf clang+llvm-5.0.1-x86_64-apple-darwin.tar.xz
       ln -s clang+llvm-5.0.1-final-x86_64-apple-darwin/bin/llvm-config llvm-config-5.0
       ln -s clang+llvm-5.0.1-final-x86_64-apple-darwin/bin/clang clang-5.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   matrix:
   - LLVM_CONFIG=llvm-config-3.8 CLANG=clang-3.8
   - LLVM_CONFIG=llvm-config-3.5 CLANG=clang-3.5
+  - LLVM_CONFIG=llvm-config-5.0 CLANG=clang-5.0
   - LLVM_CONFIG=llvm-config-6.0 CLANG=clang-6.0
 
 matrix:
@@ -33,6 +34,12 @@ before_install:
         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         for i in {1..5}; do sudo apt-get update -y && break || sleep 15; done
         sudo apt-get install -y llvm-6.0-dev clang-6.0 libclang-6.0-dev llvm-6.0-dev
+      elif [[ "$LLVM_CONFIG" = "llvm-config-5.0" ]]; then
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo apt-add-repository -y "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        for i in {1..5}; do sudo apt-get update -y && break || sleep 15; done
+        sudo apt-get install -y llvm-5.0-dev clang-5.0 libclang-5.0-dev llvm-5.0-dev
       else
         sudo apt-get install -qq clang-3.5 libclang-3.5-dev llvm-3.8-dev clang-3.8 libclang-3.8-dev llvm-3.8-dev
       fi
@@ -48,6 +55,11 @@ before_install:
       tar xf clang+llvm-3.5.2-x86_64-apple-darwin.tar.xz
       ln -s clang+llvm-3.5.2-x86_64-apple-darwin/bin/llvm-config llvm-config-3.5
       ln -s clang+llvm-3.5.2-x86_64-apple-darwin/bin/clang clang-3.5
+      
+      curl -O http://releases.llvm.org/5.0.1/clang+llvm-5.0.1-x86_64-apple-darwin.tar.xz
+      tar xf clang+llvm-5.0.1-x86_64-apple-darwin.tar.xz
+      ln -s clang+llvm-5.0.1-x86_64-apple-darwin/bin/llvm-config llvm-config-5.0
+      ln -s clang+llvm-5.0.1-x86_64-apple-darwin/bin/clang clang-5.0
 
       curl -O http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz
       tar xf clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,9 @@ before_install:
       ln -s clang+llvm-3.5.2-x86_64-apple-darwin/bin/clang clang-3.5
       
       curl -O http://releases.llvm.org/5.0.1/clang+llvm-5.0.1-x86_64-apple-darwin.tar.xz
-      tar xf clang+llvm-5.0.1-x86_64-apple-darwin.tar.xz
-      ln -s clang+llvm-5.0.1-x86_64-apple-darwin/bin/llvm-config llvm-config-5.0
-      ln -s clang+llvm-5.0.1-x86_64-apple-darwin/bin/clang clang-5.0
+      tar xf clang+llvm-5.0.1-final-x86_64-apple-darwin.tar.xz
+      ln -s clang+llvm-5.0.1-final-x86_64-apple-darwin/bin/llvm-config llvm-config-5.0
+      ln -s clang+llvm-5.0.1-final-x86_64-apple-darwin/bin/clang clang-5.0
 
       curl -O http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz
       tar xf clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
   exclude:
     - os: osx
       compiler: gcc
+    - os: osx
+      env: LLVM_CONFIG=llvm-config-5.0 CLANG=clang-5.0
 # blacklist some branches
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo apt-add-repository -y "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-        sudo apt-get update -y
+        for i in {1..5}; do sudo apt-get update -y && break || sleep 15; done
         sudo apt-get install -y llvm-6.0-dev clang-6.0 libclang-6.0-dev llvm-6.0-dev
       else
         sudo apt-get install -qq clang-3.5 libclang-3.5-dev llvm-3.8-dev clang-3.8 libclang-3.8-dev llvm-3.8-dev

--- a/src/llvmheaders.h
+++ b/src/llvmheaders.h
@@ -64,6 +64,8 @@
 #include "llvmheaders_38.h"
 #elif LLVM_VERSION == 39
 #include "llvmheaders_39.h"
+#elif LLVM_VERSION == 50
+#include "llvmheaders_50.h"
 #elif LLVM_VERSION == 60
 #include "llvmheaders_60.h"
 #else

--- a/src/llvmheaders_50.h
+++ b/src/llvmheaders_50.h
@@ -1,0 +1,32 @@
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/Analysis/CallGraphSCCPass.h"
+#include "llvm/Analysis/CallGraph.h"
+#include "llvm/IR/DIBuilder.h"
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/Mangler.h"
+//#include "llvm/ExecutionEngine/ObjectImage.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/Linker/Linker.h"
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/Target/TargetSubtargetInfo.h"
+
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "clang/Rewrite/Frontend/Rewriters.h"
+#include "llvm/IR/DiagnosticPrinter.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/Object/SymbolSize.h"
+
+#define LLVM_PATH_TYPE std::string
+#define RAW_FD_OSTREAM_NONE sys::fs::F_None
+#define RAW_FD_OSTREAM_BINARY sys::fs::F_None
+#define HASFNATTR(attr) getAttributes().hasAttribute(AttributeSet::FunctionIndex, Attribute :: attr)
+#define ADDFNATTR(attr) addFnAttr(Attribute :: attr)
+#define ATTRIBUTE Attributes

--- a/src/llvmheaders_60.h
+++ b/src/llvmheaders_60.h
@@ -24,6 +24,9 @@
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Object/SymbolSize.h"
 
+#include "llvm/Bitcode/BitcodeReader.h"
+#include "llvm/Support/Error.h"
+
 #define LLVM_PATH_TYPE std::string
 #define RAW_FD_OSTREAM_NONE sys::fs::F_None
 #define RAW_FD_OSTREAM_BINARY sys::fs::F_None

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -174,7 +174,11 @@ class TerraSectionMemoryManager : public SectionMemoryManager {
 
     public:
 
+#if LLVM_VERSION > 50
     TerraSectionMemoryManager(TerraCompilationUnit * CU_in, MemoryMapper *MM = nullptr) : SectionMemoryManager(MM) {
+#else
+    TerraSectionMemoryManager(TerraCompilationUnit * CU_in) : SectionMemoryManager() {
+#endif
         CU = CU_in;
     }
 
@@ -3063,7 +3067,7 @@ static int terra_linkllvmimpl(lua_State * L) {
     }
     #if LLVM_VERSION == 36
     ErrorOr<Module *> mm = parseBitcodeFile(mb.get()->getMemBufferRef(),*TT->ctx);
-    #elif LLVM_VERSION >= 60
+    #elif LLVM_VERSION >= 50
     Expected<std::unique_ptr<Module>> mm = parseBitcodeFile(mb.get()->getMemBufferRef(),*TT->ctx);
     #elif LLVM_VERSION >= 37
     ErrorOr<std::unique_ptr<Module>> mm = parseBitcodeFile(mb.get()->getMemBufferRef(),*TT->ctx);
@@ -3082,7 +3086,7 @@ static int terra_linkllvmimpl(lua_State * L) {
                 terra_reporterror(T, "linkllvm: %s\n", mm.getError().message().c_str());
             #endif
         } else {
-        #if LLVM_VERSION >= 60
+        #if LLVM_VERSION >= 50
             std::string Msg;
             raw_string_ostream S((Msg));
             logAllUnhandledErrors(mm.takeError(), S, "");

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -444,7 +444,9 @@ static void InitializeJIT(TerraCompilationUnit * CU) {
     if (!CU->ee)
         terra_reporterror(CU->T,"llvm: %s\n",err.c_str());
     CU->jiteventlistener = new DisassembleFunctionListener(CU);
+#if LLVM_VERSION < 50
     CU->ee->RegisterJITEventListener(CU->jiteventlistener);
+#endif
 }
 
 int terra_compilerinit(struct terra_State * T) {
@@ -636,6 +638,7 @@ class Types {
         return true;
     }
     StructType * CreateStruct(Obj * typ) {
+#if LLVM_VERSION < 50
         //check to see if it was initialized externally first
         if(typ->boolean("llvm_definingfunction")) {
             const char * name = typ->string("llvm_definingfunction");
@@ -645,6 +648,7 @@ class Types {
             assert(st);
             return st;
         }
+#endif
         std::string name = typ->asstring("name");
         bool isreserved = beginsWith(name, "struct.") || beginsWith(name, "union.");
         name = (isreserved) ? std::string("$") + name : name;

--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -189,12 +189,17 @@ void moduleToPTX(terra_State * T, llvm::Module * M, int major, int minor, std::s
 
     auto &LDEVICE = *E_LDEVICE;
 
-    llvm::Linker Linker(*M);
-    Linker.linkInModule(std::move(LDEVICE));
 
     llvm::TargetOptions opt;
     auto RM = llvm::Optional<llvm::Reloc::Model>();
     auto TargetMachine = Target->createTargetMachine("nvptx64-nvidia-cuda", cpuopt, Features, opt, RM);
+
+    LDEVICE->setTargetTriple("nvptx64-nvidia-cuda");
+    LDEVICE->setDataLayout(TargetMachine->createDataLayout());
+
+    llvm::Linker Linker(*M);
+    Linker.linkInModule(std::move(LDEVICE));
+
     M->setDataLayout(TargetMachine->createDataLayout());
 
     llvm::SmallString<2048> dest;

--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -50,7 +50,7 @@ struct terra_CUDAState {
     int initialized;
     #define INIT_SYM(x) decltype(&::x) x;
     CUDA_SYM(INIT_SYM)
-    #undef INIT_SYM    
+    #undef INIT_SYM
 };
 
 void initializeNVVMState(terra_State * T) {
@@ -80,7 +80,7 @@ static void annotateKernel(terra_State * T, llvm::Module * M, llvm::Function * k
     vals.push_back(llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(llvm::Type::getInt32Ty(ctx), value)));
     #endif
     llvm::MDNode * node = llvm::MDNode::get(ctx, vals);
-    annot->addOperand(node); 
+    annot->addOperand(node);
 }
 
 static const char * cudadatalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64";
@@ -95,7 +95,7 @@ public:
 #endif
 
 void moduleToPTX(terra_State * T, llvm::Module * M, int major, int minor, std::string * buf, const char * libdevice) {
-    
+
 #if LLVM_VERSION < 38
     for(llvm::Module::iterator it = M->begin(), end = M->end(); it != end; ++it) {
         it->setAttributes(llvm::AttributeSet()); //remove annotations because syntax doesn't match
@@ -111,7 +111,7 @@ void moduleToPTX(terra_State * T, llvm::Module * M, int major, int minor, std::s
     else
         M->setTargetTriple(""); //clear these because nvvm doesn't like them
     M->setDataLayout(""); //nvvm doesn't like data layout either
-    
+
     std::stringstream device;
     device << "-arch=compute_" << major << minor;
     std::string deviceopt = device.str();
@@ -147,7 +147,7 @@ void moduleToPTX(terra_State * T, llvm::Module * M, int major, int minor, std::s
     CUDA_DO(T->cuda->nvvmAddModuleToProgram(prog, llvmir.data(), llvmir.size(), M->getModuleIdentifier().c_str()));
     int numOptions = 1;
     const char * options[] = { deviceopt.c_str() };
-    
+
     size_t size;
     int err = T->cuda->nvvmCompileProgram(prog, numOptions, options);
     if (err != CUDA_SUCCESS) {
@@ -155,17 +155,17 @@ void moduleToPTX(terra_State * T, llvm::Module * M, int major, int minor, std::s
         buf->resize(size);
         CUDA_DO(T->cuda->nvvmGetProgramLog(prog, &(*buf)[0]));
         terra_reporterror(T,"%s:%d: nvvm error reported (%d)\n %s\n",__FILE__,__LINE__,err,buf->c_str());
-        
+
     }
     CUDA_DO(T->cuda->nvvmGetCompiledResultSize(prog, &size));
     buf->resize(size);
     CUDA_DO(T->cuda->nvvmGetCompiledResult(prog, &(*buf)[0]));
 #else
-	std::stringstream cpu;
+    std::stringstream cpu;
     cpu << "sm_" << major << minor;
     std::string cpuopt = cpu.str();
-	
-	auto Features = "";
+
+    auto Features = "";
 
     std::string Error;
     auto Target = llvm::TargetRegistry::lookupTarget("nvptx64-nvidia-cuda", Error);
@@ -186,44 +186,44 @@ void moduleToPTX(terra_State * T, llvm::Module * M, int major, int minor, std::s
         llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(), "[CUDA Error] ");
         return;
     }
-    
+
     auto &LDEVICE = *E_LDEVICE;
 
     llvm::Linker Linker(*M);
     Linker.linkInModule(std::move(LDEVICE));
 
-	llvm::TargetOptions opt;
-	auto RM = llvm::Optional<llvm::Reloc::Model>();
-	auto TargetMachine = Target->createTargetMachine("nvptx64-nvidia-cuda", cpuopt, Features, opt, RM);
-	M->setDataLayout(TargetMachine->createDataLayout());
-	
+    llvm::TargetOptions opt;
+    auto RM = llvm::Optional<llvm::Reloc::Model>();
+    auto TargetMachine = Target->createTargetMachine("nvptx64-nvidia-cuda", cpuopt, Features, opt, RM);
+    M->setDataLayout(TargetMachine->createDataLayout());
+
     llvm::SmallString<2048> dest;
     llvm::raw_svector_ostream str_dest(dest);
-	
-	llvm::PassManagerBuilder PMB;
+
+    llvm::PassManagerBuilder PMB;
     PMB.OptLevel = 3;
     PMB.SizeLevel = 0;
     PMB.LoopVectorize = false;
-	auto FileType = llvm::TargetMachine::CGFT_AssemblyFile;
+    auto FileType = llvm::TargetMachine::CGFT_AssemblyFile;
 
     llvm::legacy::PassManager PM;
     TargetMachine->adjustPassManager(PMB);
-    
+
     PMB.populateModulePassManager(PM);
 
-	if (TargetMachine->addPassesToEmitFile(PM, str_dest, FileType)) {
-		llvm::errs() << "TargetMachine can't emit a file of this type\n";
-		return;
-	}
-    
+    if (TargetMachine->addPassesToEmitFile(PM, str_dest, FileType)) {
+        llvm::errs() << "TargetMachine can't emit a file of this type\n";
+        return;
+    }
+
     PM.run(*M);
-	buf->resize(dest.size());
+    buf->resize(dest.size());
 
     // {
-	// 	std::stringstream outs;
-	// 	outs << dest.size() << std::endl;
-	// 	printf("[CUDA] Result size: %s\n", outs.str().c_str());
-	// }
+    // 	std::stringstream outs;
+    // 	outs << dest.size() << std::endl;
+    // 	printf("[CUDA] Result size: %s\n", outs.str().c_str());
+    // }
 
     (*buf) = dest.str();
 #endif
@@ -240,7 +240,7 @@ static std::string sanitizeName(std::string name) {
         else
             out << "_$" << (int) c << "_";
     }
-	out.flush();
+    out.flush();
     return s;
 }
 
@@ -272,7 +272,7 @@ int terra_toptx(lua_State * L) {
         annotateKernel(T,M,kernel,annotationname,annotationvalue);
         lua_pop(L,4); //annotation table and 3 values in it
     }
-    
+
     //sanitize names
     for(llvm::Module::iterator it = M->begin(), end = M->end(); it != end; ++it) {
         const char * prefix = "cudart:";
@@ -288,7 +288,7 @@ int terra_toptx(lua_State * L) {
     for(llvm::Module::global_iterator it = M->global_begin(), end = M->global_end(); it != end; ++it) {
         it->setName(sanitizeName(it->getName()));
     }
-	
+
     std::string ptx;
     moduleToPTX(T,M,major,minor,&ptx,libdevice);
     if(dumpmodule) {
@@ -311,7 +311,7 @@ int terra_cudainit(struct terra_State * T) {
     const char * libnvvmpath = lua_tostring(T->L,-1);
     lua_pop(T->L,2); //path and cudalibpaths
     if(llvm::sys::DynamicLibrary::LoadLibraryPermanently(libnvvmpath)) {
-		llvm::SmallString<256> err;
+        llvm::SmallString<256> err;
         err.append("failed to load libnvvm at: ");
         err.append(libnvvmpath);
         lua_pushstring(T->L,err.c_str());
@@ -322,7 +322,7 @@ int terra_cudainit(struct terra_State * T) {
     T->cuda = (terra_CUDAState*) malloc(sizeof(terra_CUDAState));
     T->cuda->initialized = 0; /* actual CUDA initalization is done on first call to terra_cudacompile */
                               /* this function just registers all the Lua state associated with CUDA */
-    
+
     lua_pushlightuserdata(T->L,(void*)T);
     lua_pushcclosure(T->L,terra_toptx,1);
     lua_setfield(T->L,-2,"toptximpl");

--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -107,7 +107,7 @@ void moduleToPTX(terra_State * T, llvm::Module * M, int major, int minor, std::s
     CUDA_DO(T->cuda->nvvmVersion(&nmajor,&nminor));
     int nversion = nmajor*10 + nminor;
     if(nversion >= 12)
-        M->setTargetTriple("nvptx64-unknown-cuda");
+        M->setTargetTriple("nvptx64-nvidia-cuda");
     else
         M->setTargetTriple(""); //clear these because nvvm doesn't like them
     M->setDataLayout(""); //nvvm doesn't like data layout either
@@ -165,7 +165,7 @@ void moduleToPTX(terra_State * T, llvm::Module * M, int major, int minor, std::s
     cpu << "sm_" << major << minor;
     std::string cpuopt = cpu.str();
 	
-	auto Features = "";
+	auto Features = "+ptx60";
 
     std::string Error;
     auto Target = llvm::TargetRegistry::lookupTarget("nvptx64-nvidia-cuda", Error);
@@ -193,15 +193,15 @@ void moduleToPTX(terra_State * T, llvm::Module * M, int major, int minor, std::s
 		llvm::errs() << "TargetMachine can't emit a file of this type\n";
 		return;
 	}
-
-	pass.run(*M);
+    
+    pass.run(*M);
 	buf->resize(dest.size());
 
-    {
-		std::stringstream outs;
-		outs << dest.size() << std::endl;
-		printf("[CUDA] Result size: %s\n", outs.str().c_str());
-	}
+    // {
+	// 	std::stringstream outs;
+	// 	outs << dest.size() << std::endl;
+	// 	printf("[CUDA] Result size: %s\n", outs.str().c_str());
+	// }
 
     (*buf) = dest.str();
 #endif

--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -496,7 +496,7 @@ public:
             0));
         }
         F->setParams(params);
-        #if LLVM_VERSION >= 50
+        #if LLVM_VERSION >= 60
         CompoundStmt * stmts = CompoundStmt::Create(*Context, outputstmts, SourceLocation(), SourceLocation());
         #elif LLVM_VERSION >= 33
         CompoundStmt * stmts = new (*Context) CompoundStmt(*Context, outputstmts, SourceLocation(), SourceLocation());

--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -455,6 +455,8 @@ public:
                 InternalName.insert(InternalName.begin(), '\01');
             }
             #endif
+            // Uncomment for mangling issue debugging
+            // llvm::errs() << "[mangle] " << FuncName << "=" << InternalName << "\n";
         }
 
         CreateFunction(FuncName,InternalName,&typ);

--- a/src/tllvmutil.cpp
+++ b/src/tllvmutil.cpp
@@ -87,7 +87,7 @@ void llvmutil_addoptimizationpasses(PassManagerBase * fpm) {
     PMB.populateModulePassManager(W);
 }
 
-#if LLVM_VERSION < 60
+#if LLVM_VERSION < 50
 struct SimpleMemoryObject : public MemoryObject {
   uint64_t getBase() const { return 0; }
   uint64_t getExtent() const { return ~0ULL; }


### PR DESCRIPTION
This PR should be able to enable CUDA for LLVM 5 and 6 :)

```
cudaagg.t:
[CUDA] Result size: 2352

cudaaggregate.t:
[CUDA] Result size: 2420

cudaatomic.t:
[CUDA] Result size: 336

CUDA Module:
; ModuleID = 'terra'
source_filename = "terra"
target datalayout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64"
target triple = "nvptx64-unknown-cuda"

; Function Attrs: alwaysinline
define void @bar(i32*) #0 {
entry:
  %1 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
  call void asm sideeffect "red.global.max.u32 [$0], $1;", "l,r"(i32* %0, i32 %1)
  ret void
}

; Function Attrs: nounwind readnone
declare i32 @llvm.nvvm.read.ptx.sreg.tid.x() #1

; Function Attrs: nounwind
declare void @llvm.stackprotector(i8*, i8**) #2

attributes #0 = { alwaysinline }
attributes #1 = { nounwind readnone }
attributes #2 = { nounwind }

!nvvm.annotations = !{!0}

!0 = !{void (i32*)* @bar, !"kernel", i32 1}
Generated PTX:
//
// Generated by LLVM NVPTX Back-End
//

.version 5.0
.target sm_61
.address_size 64

	// .globl	bar

.visible .entry bar(
	.param .u64 bar_param_0
)
{
	.reg .b32 	%r<2>;
	.reg .b64 	%rd<2>;

	ld.param.u64 	%rd1, [bar_param_0];
	mov.u32 	%r1, %tid.x;
	// begin inline asm
	red.global.max.u32 [%rd1], %r1;
	// end inline asm
	ret;
}



cudaconst2.t:
[CUDA] Result size: 214

cudaglobal.t:
[CUDA] Result size: 708

cudahello.t:
[CUDA] Result size: 953

0
1
2
and were done
cudaoffline.t:
[CUDA] Result size: 708

cudaoo.t:
[CUDA] Result size: 144

cudaprintf.t:
[CUDA] Result size: 1249

a = 0, b = 1.000000, c = 2
a = 1, b = 2.000000, c = 3
a = 2, b = 3.000000, c = 4
cudashared.t:
[CUDA] Result size: 690

CUDA Module:
; ModuleID = 'terra'
source_filename = "terra"
target datalayout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64"
target triple = "nvptx64-unknown-cuda"

@"_$60_global_$62_" = addrspace(3) global [1024 x i32] undef

; Function Attrs: alwaysinline
define void @bar(i32*) #0 {
entry:
  %1 = addrspacecast i32* %0 to i32 addrspace(1)*
  %2 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
  %3 = call i8* @llvm.nvvm.ptr.shared.to.gen.p0i8.p3i8(i8 addrspace(3)* bitcast ([1024 x i32] addrspace(3)* @"_$60_global_$62_" to i8 addrspace(3)*))
  %4 = bitcast i8* %3 to i32*
  %5 = sext i32 %2 to i64
  %6 = getelementptr i32, i32* %4, i64 %5
  store i32 %2, i32* %6
  call void @llvm.nvvm.barrier0()
  %7 = sub i32 1023, %2
  %8 = sext i32 %7 to i64
  %9 = getelementptr i32, i32* %4, i64 %8
  %10 = load i32, i32* %9
  %11 = getelementptr i32, i32 addrspace(1)* %1, i64 %5
  store i32 %10, i32 addrspace(1)* %11
  ret void
}

; Function Attrs: nounwind readnone
declare i32 @llvm.nvvm.read.ptx.sreg.tid.x() #1

; Function Attrs: nounwind readnone
declare i8* @llvm.nvvm.ptr.shared.to.gen.p0i8.p3i8(i8 addrspace(3)*) #1

; Function Attrs: convergent nounwind
declare void @llvm.nvvm.barrier0() #2

; Function Attrs: nounwind
declare void @llvm.stackprotector(i8*, i8**) #3

attributes #0 = { alwaysinline }
attributes #1 = { nounwind readnone }
attributes #2 = { convergent nounwind }
attributes #3 = { nounwind }

!nvvm.annotations = !{!0}

!0 = !{void (i32*)* @bar, !"kernel", i32 1}
Generated PTX:
//
// Generated by LLVM NVPTX Back-End
//

.version 5.0
.target sm_61
.address_size 64

	// .globl	bar
.visible .shared .align 4 .b8 _$60_global_$62_[4096];

.visible .entry bar(
	.param .u64 bar_param_0
)
{
	.reg .b32 	%r<5>;
	.reg .b64 	%rd<10>;

	ld.param.u64 	%rd1, [bar_param_0];
	cvta.to.global.u64 	%rd2, %rd1;
	mov.u32 	%r1, %tid.x;
	mov.u64 	%rd3, _$60_global_$62_;
	cvta.shared.u64 	%rd4, %rd3;
	mul.wide.s32 	%rd5, %r1, 4;
	add.s64 	%rd6, %rd4, %rd5;
	st.u32 	[%rd6], %r1;
	bar.sync 	0;
	mov.u32 	%r2, 1023;
	sub.s32 	%r3, %r2, %r1;
	mul.wide.s32 	%rd7, %r3, 4;
	add.s64 	%rd8, %rd4, %rd7;
	ld.u32 	%r4, [%rd8];
	add.s64 	%rd9, %rd2, %rd5;
	st.global.u32 	[%rd9], %r4;
	ret;
}



cudatest.t:
[CUDA] Result size: 930

cudatex.t:
[CUDA] Result size: 1147

0.000000
1.000000
2.000000
3.000000
4.000000
5.000000
6.000000
7.000000
8.000000
9.000000
and were done
=================

521 tests passed. 0 tests failed.
```

Tested on my Mac running:
```
LLVM_CONFIG=/usr/local/Cellar/llvm/6.0.1/bin/llvm-config
ENABLE_CUDA=1
CUDA_HOME=/Developer/NVIDIA/CUDA-9.2
```