### PR TITLE
LLVM 7.0 Support with CUDA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   - LLVM_CONFIG=llvm-config-3.5 CLANG=clang-3.5
   - LLVM_CONFIG=llvm-config-5.0 CLANG=clang-5.0
   - LLVM_CONFIG=llvm-config-6.0 CLANG=clang-6.0
+  - LLVM_CONFIG=llvm-config-7.0 CLANG=clang-7.0
 
 matrix:
   exclude:
@@ -25,12 +26,19 @@ branches:
   only:
     - develop
     - master
+    - dev-llvm70
 before_install:
   - |
     if [[ "$(uname)" = "Linux" ]]; then
       sudo apt-get update -qq
       sudo apt-get install wget
-      if [[ "$LLVM_CONFIG" = "llvm-config-6.0" ]]; then
+      if [[ "$LLVM_CONFIG" = "llvm-config-7.0" ]]; then
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo apt-add-repository -y "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main"
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        for i in {1..5}; do sudo apt-get update -y && break || sleep 15; done
+        sudo apt-get install -y llvm-7.0-dev clang-7.0 libclang-7.0-dev llvm-7.0-dev
+      elif [[ "$LLVM_CONFIG" = "llvm-config-6.0" ]]; then
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo apt-add-repository -y "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
@@ -67,6 +75,11 @@ before_install:
       tar xf clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz
       ln -s clang+llvm-6.0.0-x86_64-apple-darwin/bin/llvm-config llvm-config-6.0
       ln -s clang+llvm-6.0.0-x86_64-apple-darwin/bin/clang clang-6.0
+
+      curl -O http://releases.llvm.org/7.0.0/clang+llvm-7.0.0-x86_64-apple-darwin.tar.xz
+      tar xf clang+llvm-7.0.0-x86_64-apple-darwin.tar.xz
+      ln -s clang+llvm-7.0.0-x86_64-apple-darwin/bin/llvm-config llvm-config-7.0
+      ln -s clang+llvm-7.0.0-x86_64-apple-darwin/bin/clang clang-7.0
 
       export PATH=$PWD:$PATH
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,11 @@ before_install:
       else
         sudo apt-get install -qq clang-3.5 libclang-3.5-dev llvm-3.8-dev clang-3.8 libclang-3.8-dev llvm-3.8-dev
       fi
+
+      curl -O -L https://jaist.dl.sourceforge.net/project/p7zip/p7zip/16.02/p7zip_16.02_x86_linux_bin.tar.bz2
+      
+      ln -s p7zip_16.02/bin/7z 7z
+      export PATH=$PWD:$PATH
     fi
   - |
     if [[ "$(uname)" = "Darwin" ]]; then
@@ -83,9 +88,9 @@ before_install:
         ln -s clang+llvm-7.0.0-x86_64-apple-darwin/bin/clang clang-7.0
       fi
       
-      curl -O https://homebrew.bintray.com/bottles/p7zip-16.02_1.el_capitan.bottle.tar.gz
+      curl -L -O https://homebrew.bintray.com/bottles/p7zip-16.02_1.el_capitan.bottle.tar.gz
       tar xf p7zip-16.02_1.el_capitan.bottle.tar.gz
-      ln -s p7zip/16.02_1/bin/7z 7z
+      ln -s p7zip/16.02_1/lib/p7zip/7z 7z
       export PATH=$PWD:$PATH
     fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,9 +83,9 @@ before_install:
         ln -s clang+llvm-7.0.0-x86_64-apple-darwin/bin/clang clang-7.0
       fi
       
-      curl -O https://raw.githubusercontent.com/develar/7zip-bin/master/mac/7za
-      chmod +x ./7za
-      mv ./7za ./7z
+      curl -O https://homebrew.bintray.com/bottles/p7zip-16.02_1.el_capitan.bottle.tar.gz
+      tar xf p7zip-16.02_1.el_capitan.bottle.tar.gz
+      ln -s p7zip/16.02_1/bin/7z 7z
       export PATH=$PWD:$PATH
     fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ before_install:
     fi
 script:
   - |
-    if [ "$(uname)" = "Linux" ] && [ "$LLVM_CONFIG" != "llvm-config-7.0" ]; then
+    if [ "$(uname)" = "Linux" ] && [ "$LLVM_CONFIG" = "llvm-config-7.0" ]; then
       make LLVM_CONFIG=$(which llvm-config-7) CLANG=$(which clang-7) test
     else
       make LLVM_CONFIG=$(which $LLVM_CONFIG) CLANG=$(which $CLANG) test

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,8 @@ before_install:
       fi
 
       curl -O -L https://jaist.dl.sourceforge.net/project/p7zip/p7zip/16.02/p7zip_16.02_x86_linux_bin.tar.bz2
-      
-      ln -s p7zip_16.02/bin/7z 7z
+      tar xf p7zip_16.02_x86_linux_bin.tar.bz2
+      export PATH=$PWD/p7zip_16.02/bin:$PATH
       export PATH=$PWD:$PATH
     fi
   - |
@@ -90,7 +90,7 @@ before_install:
       
       curl -L -O https://homebrew.bintray.com/bottles/p7zip-16.02_1.el_capitan.bottle.tar.gz
       tar xf p7zip-16.02_1.el_capitan.bottle.tar.gz
-      ln -s p7zip/16.02_1/lib/p7zip/7z 7z
+      export PATH=$PWD/p7zip/16.02_1/lib/p7zip:$PATH
       export PATH=$PWD:$PATH
     fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,13 @@ before_install:
         ln -s clang+llvm-7.0.0-x86_64-apple-darwin/bin/llvm-config llvm-config-7.0
         ln -s clang+llvm-7.0.0-x86_64-apple-darwin/bin/clang clang-7.0
       fi
-      
+
       export PATH=$PWD:$PATH
     fi
 script:
-  - make LLVM_CONFIG=$(which $LLVM_CONFIG) CLANG=$(which $CLANG) test
+  - |
+    if [ "$(uname)" = "Linux" ] && [ "$LLVM_CONFIG" != "llvm-config-7.0" ]; then
+      make LLVM_CONFIG=$(which llvm-config-7) CLANG=$(which clang-7) test
+    else
+      make LLVM_CONFIG=$(which $LLVM_CONFIG) CLANG=$(which $CLANG) test
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - |
     if [[ "$(uname)" = "Linux" ]]; then
       sudo apt-get update -qq
-      sudo apt-get install wget
+      sudo apt-get install wget p7zip
       if [[ "$LLVM_CONFIG" = "llvm-config-7.0" ]]; then
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo apt-add-repository -y "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main"
@@ -82,7 +82,10 @@ before_install:
         ln -s clang+llvm-7.0.0-x86_64-apple-darwin/bin/llvm-config llvm-config-7.0
         ln -s clang+llvm-7.0.0-x86_64-apple-darwin/bin/clang clang-7.0
       fi
-
+      
+      curl -O https://raw.githubusercontent.com/develar/7zip-bin/master/mac/7za
+      chmod +x ./7za
+      mv ./7za ./7z
       export PATH=$PWD:$PATH
     fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - |
     if [[ "$(uname)" = "Linux" ]]; then
       sudo apt-get update -qq
-      sudo apt-get install wget p7zip-full p7zip-rar
+      sudo apt-get install -y wget libc6-i386
       if [[ "$LLVM_CONFIG" = "llvm-config-7.0" ]]; then
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo apt-add-repository -y "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main"
@@ -56,7 +56,10 @@ before_install:
 
       curl -O -L https://jaist.dl.sourceforge.net/project/p7zip/p7zip/16.02/p7zip_16.02_x86_linux_bin.tar.bz2
       tar xf p7zip_16.02_x86_linux_bin.tar.bz2
-      export PATH=$PWD/p7zip_16.02/bin:$PATH
+      (
+        cd p7zip_16.02
+        sudo ./install.sh
+      )
       export PATH=$PWD:$PATH
     fi
   - |
@@ -90,7 +93,9 @@ before_install:
       
       curl -L -O https://homebrew.bintray.com/bottles/p7zip-16.02_1.el_capitan.bottle.tar.gz
       tar xf p7zip-16.02_1.el_capitan.bottle.tar.gz
-      export PATH=$PWD/p7zip/16.02_1/lib/p7zip:$PATH
+      cat ./p7zip/16.02_1/bin/7z | (rm ./p7zip/16.02_1/bin/7z; sed "s?\@\@HOMEBREW_PREFIX\@\@/Cellar?`pwd`?g" > ./p7zip/16.02_1/bin/7z )
+      chmod +x ./p7zip/16.02_1/bin/7z
+      export PATH=$PWD/p7zip/16.02_1/bin:$PATH
       export PATH=$PWD:$PATH
     fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,31 +56,33 @@ before_install:
     fi
   - |
     if [[ "$(uname)" = "Darwin" ]]; then
-      curl -O http://releases.llvm.org/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz
-      tar xf clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz
-      ln -s clang+llvm-3.8.0-x86_64-apple-darwin/bin/llvm-config llvm-config-3.8
-      ln -s clang+llvm-3.8.0-x86_64-apple-darwin/bin/clang clang-3.8
-
-      curl -O http://releases.llvm.org/3.5.2/clang+llvm-3.5.2-x86_64-apple-darwin.tar.xz
-      tar xf clang+llvm-3.5.2-x86_64-apple-darwin.tar.xz
-      ln -s clang+llvm-3.5.2-x86_64-apple-darwin/bin/llvm-config llvm-config-3.5
-      ln -s clang+llvm-3.5.2-x86_64-apple-darwin/bin/clang clang-3.5
+      if [[ "$LLVM_CONFIG" = "llvm-config-3.8" ]]; then
+        curl -O http://releases.llvm.org/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz
+        tar xf clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz
+        ln -s clang+llvm-3.8.0-x86_64-apple-darwin/bin/llvm-config llvm-config-3.8
+        ln -s clang+llvm-3.8.0-x86_64-apple-darwin/bin/clang clang-3.8
+      elif [[ "$LLVM_CONFIG" = "llvm-config-3.5" ]]; then
+        curl -O http://releases.llvm.org/3.5.2/clang+llvm-3.5.2-x86_64-apple-darwin.tar.xz
+        tar xf clang+llvm-3.5.2-x86_64-apple-darwin.tar.xz
+        ln -s clang+llvm-3.5.2-x86_64-apple-darwin/bin/llvm-config llvm-config-3.5
+        ln -s clang+llvm-3.5.2-x86_64-apple-darwin/bin/clang clang-3.5
+      elif [[ "$LLVM_CONFIG" = "llvm-config-5.0" ]]; then
+        curl -O http://releases.llvm.org/5.0.1/clang+llvm-5.0.1-x86_64-apple-darwin.tar.xz
+        tar xf clang+llvm-5.0.1-x86_64-apple-darwin.tar.xz
+        ln -s clang+llvm-5.0.1-final-x86_64-apple-darwin/bin/llvm-config llvm-config-5.0
+        ln -s clang+llvm-5.0.1-final-x86_64-apple-darwin/bin/clang clang-5.0
+      elif [[ "$LLVM_CONFIG" = "llvm-config-6.0" ]]; then
+        curl -O http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz
+        tar xf clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz
+        ln -s clang+llvm-6.0.0-x86_64-apple-darwin/bin/llvm-config llvm-config-6.0
+        ln -s clang+llvm-6.0.0-x86_64-apple-darwin/bin/clang clang-6.0
+      elif [[ "$LLVM_CONFIG" = "llvm-config-7.0" ]]; then
+        curl -O http://releases.llvm.org/7.0.0/clang+llvm-7.0.0-x86_64-apple-darwin.tar.xz
+        tar xf clang+llvm-7.0.0-x86_64-apple-darwin.tar.xz
+        ln -s clang+llvm-7.0.0-x86_64-apple-darwin/bin/llvm-config llvm-config-7.0
+        ln -s clang+llvm-7.0.0-x86_64-apple-darwin/bin/clang clang-7.0
+      fi
       
-      curl -O http://releases.llvm.org/5.0.1/clang+llvm-5.0.1-x86_64-apple-darwin.tar.xz
-      tar xf clang+llvm-5.0.1-x86_64-apple-darwin.tar.xz
-      ln -s clang+llvm-5.0.1-final-x86_64-apple-darwin/bin/llvm-config llvm-config-5.0
-      ln -s clang+llvm-5.0.1-final-x86_64-apple-darwin/bin/clang clang-5.0
-
-      curl -O http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz
-      tar xf clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz
-      ln -s clang+llvm-6.0.0-x86_64-apple-darwin/bin/llvm-config llvm-config-6.0
-      ln -s clang+llvm-6.0.0-x86_64-apple-darwin/bin/clang clang-6.0
-
-      curl -O http://releases.llvm.org/7.0.0/clang+llvm-7.0.0-x86_64-apple-darwin.tar.xz
-      tar xf clang+llvm-7.0.0-x86_64-apple-darwin.tar.xz
-      ln -s clang+llvm-7.0.0-x86_64-apple-darwin/bin/llvm-config llvm-config-7.0
-      ln -s clang+llvm-7.0.0-x86_64-apple-darwin/bin/clang clang-7.0
-
       export PATH=$PWD:$PATH
     fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - |
     if [[ "$(uname)" = "Linux" ]]; then
       sudo apt-get update -qq
-      sudo apt-get install wget p7zip
+      sudo apt-get install wget p7zip-full p7zip-rar
       if [[ "$LLVM_CONFIG" = "llvm-config-7.0" ]]; then
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo apt-add-repository -y "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
         sudo apt-add-repository -y "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main"
         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         for i in {1..5}; do sudo apt-get update -y && break || sleep 15; done
-        sudo apt-get install -y llvm-7.0-dev clang-7.0 libclang-7.0-dev llvm-7.0-dev
+        sudo apt-get install -y llvm-7-dev clang-7 libclang-7-dev llvm-7-dev
       elif [[ "$LLVM_CONFIG" = "llvm-config-6.0" ]]; then
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo apt-add-repository -y "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"

--- a/src/llvmheaders.h
+++ b/src/llvmheaders.h
@@ -68,6 +68,8 @@
 #include "llvmheaders_50.h"
 #elif LLVM_VERSION == 60
 #include "llvmheaders_60.h"
+#elif LLVM_VERSION == 70
+#include "llvmheaders_70.h"
 #else
 #error "unsupported LLVM version"
 //for OSX code completion

--- a/src/llvmheaders_70.h
+++ b/src/llvmheaders_70.h
@@ -1,0 +1,35 @@
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/Analysis/CallGraphSCCPass.h"
+#include "llvm/Analysis/CallGraph.h"
+#include "llvm/IR/DIBuilder.h"
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/Mangler.h"
+//#include "llvm/ExecutionEngine/ObjectImage.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/Linker/Linker.h"
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/CodeGen/TargetSubtargetInfo.h"
+
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "clang/Rewrite/Frontend/Rewriters.h"
+#include "llvm/IR/DiagnosticPrinter.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/Object/SymbolSize.h"
+
+#include "llvm/Bitcode/BitcodeReader.h"
+#include "llvm/Support/Error.h"
+
+#define LLVM_PATH_TYPE std::string
+#define RAW_FD_OSTREAM_NONE sys::fs::F_None
+#define RAW_FD_OSTREAM_BINARY sys::fs::F_None
+#define HASFNATTR(attr) getAttributes().hasAttribute(AttributeSet::FunctionIndex, Attribute :: attr)
+#define ADDFNATTR(attr) addFnAttr(Attribute :: attr)
+#define ATTRIBUTE Attributes

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2922,7 +2922,11 @@ static bool SaveObject(TerraCompilationUnit * CU, Module * M, const std::string 
             return true;
         }
     } else if(filekind == "bitcode") {
+#if LLVM_VERSION < 70
         llvm::WriteBitcodeToFile(M,dest);
+#else
+        llvm::WriteBitcodeToFile(*M, dest);
+#endif
     } else if(filekind == "llvmir") {
         dest << *M;
     }

--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -216,10 +216,17 @@ void moduleToPTX(terra_State * T, llvm::Module * M, int major, int minor, std::s
 
     PMB.populateModulePassManager(PM);
 
+    #if LLVM_VERSION >= 70
+    if (TargetMachine->addPassesToEmitFile(PM, str_dest, nullptr, FileType)) {
+        llvm::errs() << "TargetMachine can't emit a file of this type\n";
+        return;
+    }
+    #else
     if (TargetMachine->addPassesToEmitFile(PM, str_dest, FileType)) {
         llvm::errs() << "TargetMachine can't emit a file of this type\n";
         return;
     }
+    #endif
 
     PM.run(*M);
     buf->resize(dest.size());

--- a/src/tllvmutil.cpp
+++ b/src/tllvmutil.cpp
@@ -191,9 +191,16 @@ bool llvmutil_emitobjfile(Module * Mod, TargetMachine * TM, bool outputobjectfil
     #else
     emitobjfile_t & destf = dest;
     #endif
+
+    #if LLVM_VERSION >= 70
+    if (TM->addPassesToEmitFile(pass, destf, nullptr, ft)) {
+        return true;
+    }
+    #else
     if (TM->addPassesToEmitFile(pass, destf, ft)) {
         return true;
     }
+    #endif
 
     pass.run(*Mod);
     
@@ -403,7 +410,18 @@ error_code llvmutil_createtemporaryfile(const Twine &Prefix, StringRef Suffix, S
 int llvmutil_executeandwait(LLVM_PATH_TYPE program, const char ** args, std::string * err) {
 #if LLVM_VERSION >= 34
     bool executionFailed = false;
+    #if LLVM_VERSION >= 70
+    std::vector<llvm::StringRef> argsRef;
+    int args_ptr = 0;
+    while (args[args_ptr] != NULL) {
+        argsRef.push_back(llvm::StringRef(args[args_ptr]));
+        args_ptr++;
+    }
+
+    llvm::sys::ProcessInfo Info = llvm::sys::ExecuteNoWait(program, argsRef, llvm::Optional<ArrayRef<llvm::StringRef>>(), {}, 0, err, &executionFailed);
+    #else
     llvm::sys::ProcessInfo Info = llvm::sys::ExecuteNoWait(program,args,nullptr,{},0,err,&executionFailed);
+    #endif
     if(executionFailed)
         return -1;
     #ifndef _WIN32

--- a/src/unpacklibraries.lua
+++ b/src/unpacklibraries.lua
@@ -20,6 +20,6 @@ for line in io.lines() do
     local archivename = archivepath:match("/([^/]*)%.a$")
     if not exists( ("%s/%s/%s"):format(destination,archivename,objectfile) ) then
         exe("mkdir -p %s/%s",destination,archivename) 
-        exe("cd %s/%s; 7z x -aou %s %s",destination,archivename,archivepath,objectfile)
+        exe("cd %s/%s; 7z x -aou %s %s > /dev/null",destination,archivename,archivepath,objectfile)
     end
 end 

--- a/src/unpacklibraries.lua
+++ b/src/unpacklibraries.lua
@@ -20,6 +20,6 @@ for line in io.lines() do
     local archivename = archivepath:match("/([^/]*)%.a$")
     if not exists( ("%s/%s/%s"):format(destination,archivename,objectfile) ) then
         exe("mkdir -p %s/%s",destination,archivename) 
-        exe("cd %s/%s; ar x %s %s",destination,archivename,archivepath,objectfile)
+        exe("cd %s/%s; 7z x -aou %s %s",destination,archivename,archivepath,objectfile)
     end
 end 


### PR DESCRIPTION
LLVM 7.0 is not a huge deal however there is one crucial breaking change: The LLVM repo now starts to have C++ files with same filenames. same source name -> same object name, and when compressed into one `.a` archive, the second one never gets uncompressed, leading to a link error.

Sadly, no elegant cross-platform solution is known to me that handles this situation well. Either we report this to the upstream, or we use some other program to uncompress the archive.

My solution is simple but not elegant: I added a hard dependency to `p7zip`, which is the only thing known to me that works with the 1970-era ar format.

Travis scripts are already adjusted to accommodate this change.

The code explains for itself, BTW.