### PR TITLE
Define terralib.os for forwards-compatibility with PUC Lua

### DIFF
--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -3,6 +3,8 @@ local ffi = require("ffi")
 local asdl = require("asdl")
 local List = asdl.List
 
+terra.os = ffi.os
+
 -- LINE COVERAGE INFORMATION, must run test script with luajit and not terra to avoid overwriting coverage with old version
 if false then
     local converageloader = loadfile("coverageinfo.lua")


### PR DESCRIPTION
This makes master compatible with the develop branch, so users can start using `terralib.os` now to avoid unnecessary dependencies on the `ffi` library.