### PR TITLE
build on aarch64 (nvidia xavier)

### DIFF
--- a/src/tdebug.cpp
+++ b/src/tdebug.cpp
@@ -3,7 +3,7 @@
 #include "terrastate.h"
 #include "tcompilerstate.h"
 
-#if !defined(__arm__)
+#if !defined(__arm__) && !defined(__aarch64__)
 
 #ifndef _WIN32
 #include <execinfo.h>


### PR DESCRIPTION
This is the minimum change required to build on NVIDIA Xavier ( linux4tegra on aarch64 ) in addition to setting the luajit version to 2.1 ( I used beta3 )
When using CMAKE I also have to disable LLVM_ENABLE_RTTI 

I have not yet been able to get CUDA (10) to work, even though it appears to build with cuda when the makefile.inc is configured. 