### PR TITLE
Search for imported structs across all compilation targets

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -308,8 +308,10 @@ bool HostHasAVX() {
 int terra_inittarget(lua_State * L) {
     terra_State * T = terra_getstate(L, 1);
     TerraTarget * TT = new TerraTarget();
-    TT->nreferences = 1;
-    
+    TT->id = T->targets.size();
+    T->targets.push_back(TT);
+    TT->nreferences = 2;
+
     if(!lua_isnil(L, 1)) {
         TT->Triple = lua_tostring(L,1);
     } else {
@@ -488,7 +490,7 @@ int terra_compilerinit(struct terra_State * T) {
     }
     return 0;
 }
-static void freetarget(TerraTarget * TT) {
+void freetarget(TerraTarget * TT) {
     assert(TT->nreferences > 0);
     if(0 == --TT->nreferences) {
         delete TT->external;
@@ -649,17 +651,18 @@ class Types {
         return true;
     }
     StructType * CreateStruct(Obj * typ) {
-#if LLVM_VERSION < 50
         //check to see if it was initialized externally first
         if(typ->boolean("llvm_definingfunction")) {
             const char * name = typ->string("llvm_definingfunction");
-            Function * df = CU->TT->external->getFunction(name); assert(df);
+            size_t target_id = typ->number("llvm_definingtarget");
+            TerraTarget * TT = T->targets[target_id];
+            assert(TT);
+            Function * df = TT->external->getFunction(name); assert(df);
             int argpos = typ->number("llvm_argumentposition");
             StructType * st = cast<StructType>(df->getFunctionType()->getParamType(argpos)->getPointerElementType());
             assert(st);
             return st;
         }
-#endif
         std::string name = typ->asstring("name");
         bool isreserved = beginsWith(name, "struct.") || beginsWith(name, "union.");
         name = (isreserved) ? std::string("$") + name : name;

--- a/src/tcompiler.h
+++ b/src/tcompiler.h
@@ -3,7 +3,9 @@
 
 struct terra_State;
 struct terra_CompilerState;
+struct TerraTarget;
 int terra_compilerinit(struct terra_State * T);
 int terra_compilerfree(struct terra_CompilerState * T);
+void freetarget(TerraTarget * TT);
 
 #endif

--- a/src/tcompilerstate.h
+++ b/src/tcompilerstate.h
@@ -22,6 +22,7 @@ struct TerraTarget {
     llvm::LLVMContext * ctx;
     llvm::Module * external; //module that holds IR for externally included things (from includec or linkllvm)
     size_t next_unused_id; //for creating names for dummy functions
+    size_t id;
 };
 
 struct TerraFunctionState { //compilation state

--- a/src/terra.cpp
+++ b/src/terra.cpp
@@ -297,6 +297,9 @@ static int terra_free(lua_State * L) {
     assert(T);
     terra_cudafree(T);
     terra_compilerfree(T->C);
+    for (TerraTarget * TT : T->targets) {
+        freetarget(TT);
+    }
     return 0;
 }
 

--- a/src/terrastate.h
+++ b/src/terrastate.h
@@ -5,16 +5,19 @@
 #include <stdint.h>
 #include <stdarg.h>
 #include <string.h>
+#include <vector>
 #include "terra.h"
 
 struct terra_CompilerState;
 struct terra_CUDAState;
+struct TerraTarget;
 
 typedef struct terra_State {
     struct lua_State * L;
     struct terra_CompilerState * C;
     struct terra_CUDAState * cuda;
     terra_Options options;
+    std::vector<TerraTarget *> targets;
 //for parser
     int nCcalls;
     char tstring_table; //&tstring_table is used as the key into the lua registry that maps strings in Lua to TString objects for the parser


### PR DESCRIPTION
This patch will allow us to import a type once using `terralib.includec` and use it in code generated for all compilation targets (e.g. both CPU and GPU functions). I expect this will solve #199, and help with some of the issues in #288. It will also allow Regent's CUDA codegen to handle imported structs.