### PR TITLE
Workaround for macOS Mojave 10.14 link error in LuaJIT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,8 @@ endif
 
 build/lib/libluajit-5.1.a: build/$(LUAJIT_TAR)
 	(cd build; tar -xf $(LUAJIT_TAR))
-	(cd $(LUAJIT_DIR); $(MAKE) install PREFIX=$(realpath build) CC=$(CC) STATIC_CC="$(CC) -fPIC")
+	# MACOSX_DEPLOYMENT_TARGET is a workaround for https://github.com/LuaJIT/LuaJIT/issues/484
+	(cd $(LUAJIT_DIR); $(MAKE) install PREFIX=$(realpath build) CC=$(CC) STATIC_CC="$(CC) -fPIC" MACOSX_DEPLOYMENT_TARGET=10.6)
 
 release/include/terra/%.h:  $(LUAJIT_INCLUDE)/%.h $(LUAJIT_LIB) 
 	cp $(LUAJIT_INCLUDE)/$*.h $@


### PR DESCRIPTION
See: https://github.com/LuaJIT/LuaJIT/issues/484

Can be reverted when the following PR is merged:
https://github.com/LuaJIT/LuaJIT/pull/485