### PR TITLE
Fix for LLVM 7.1

### DIFF
--- a/src/llvmheaders.h
+++ b/src/llvmheaders.h
@@ -68,7 +68,7 @@
 #include "llvmheaders_50.h"
 #elif LLVM_VERSION == 60
 #include "llvmheaders_60.h"
-#elif LLVM_VERSION == 70
+#elif LLVM_VERSION >= 70 && LLVM_VERSION < 80
 #include "llvmheaders_70.h"
 #else
 #error "unsupported LLVM version"


### PR DESCRIPTION
Apparently the LLVM team decided to release a version 7.1, which breaks all our assumptions that releases >= 5 are numbered X.0.