### PR TITLE
Add support for noreturn functions

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1388,6 +1388,11 @@ struct FunctionEmitter {
                     fstate->func->ADDFNATTR(NoInline);
                 }
             }
+            if(funcobj->hasfield("noreturn")) {
+                if(funcobj->boolean("noreturn")) {
+                    fstate->func->ADDFNATTR(NoReturn);
+                }
+            }
 
             if(!isextern) {
                 if(CU->optimize) {

--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -552,6 +552,10 @@ function T.terrafunction:setoptimized(v)
     assert(not (self.definition.alwaysinline and self.definition.dontoptimize),
            "setinlined(true) and setoptimized(false) are incompatible")
 end
+function T.terrafunction:setnoreturn(v)
+    assert(self:isdefined(), "attempting to set the noreturn state of an undefined function")
+    self.definition.noreturn = not not v
+end
 function T.terrafunction:disas()
     print("definition ", self:gettype())
     terra.disassemble(terra.jitcompilationunit:addvalue(self),self:compile())

--- a/tests/noreturn.t
+++ b/tests/noreturn.t
@@ -1,0 +1,9 @@
+exit = terralib.externfunction("exit", {int} -> {})
+exit:setnoreturn(true)
+
+terra foo() : {}
+    exit(0)
+end
+
+foo:compile()
+foo:disas()


### PR DESCRIPTION
Terra supports marking functions as always-inline, never-inline, and don't-optimize. LLVM also supports marking functions as noreturn. This PR exposes LLVM's noreturn attribute to Terra.