### PR TITLE
Fix stdio.h include problem

### DIFF
--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -961,9 +961,10 @@ static void optimizemodule(TerraTarget *TT, llvm::Module *M) {
 
     for (llvm::Module::iterator it = M->begin(), end = M->end(); it != end; ++it) {
         llvm::Function *fn = &*it;
-        if (fn->hasAvailableExternallyLinkage() || fn->hasLinkOnceODRLinkage()) {
+        if (fn->hasAvailableExternallyLinkage() ||
+            fn->getLinkage() == llvm::GlobalValue::LinkOnceODRLinkage) {
             fn->setLinkage(llvm::GlobalValue::WeakODRLinkage);
-        } else if (fn->hasLinkOnceLinkage()) {
+        } else if (fn->getLinkage() == llvm::GlobalValue::LinkOnceAnyLinkage) {
             fn->setLinkage(llvm::GlobalValue::WeakAnyLinkage);
         }
 #if LLVM_VERSION >= 35

--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -957,8 +957,6 @@ static void optimizemodule(TerraTarget *TT, llvm::Module *M) {
     // in some cases clang will mark stuff AvailableExternally (e.g. atoi on linux)
     // the linker will then delete it because it is not used.
     // switching it to WeakODR means that the linker will keep it even if it is not used
-    std::vector<llvm::Constant *> usedArray;
-
     for (llvm::Module::iterator it = M->begin(), end = M->end(); it != end; ++it) {
         llvm::Function *fn = &*it;
         if (fn->hasAvailableExternallyLinkage() ||

--- a/src/tllvmutil.cpp
+++ b/src/tllvmutil.cpp
@@ -261,6 +261,7 @@ struct CopyConnectedComponent : public ValueMaterializer {
                 newfn = Function::Create(fn->getFunctionType(), fn->getLinkage(),
                                          fn->getName(), dest);
                 newfn->copyAttributesFrom(fn);
+                newfn->setComdat(fn->getComdat()); // copyAttributesFrom does not copy comdats
             }
             if (!fn->isDeclaration() && newfn->isDeclaration() && copyGlobal(fn, data)) {
                 for (Function::arg_iterator II = newfn->arg_begin(), I = fn->arg_begin(),

--- a/src/tllvmutil.cpp
+++ b/src/tllvmutil.cpp
@@ -261,7 +261,8 @@ struct CopyConnectedComponent : public ValueMaterializer {
                 newfn = Function::Create(fn->getFunctionType(), fn->getLinkage(),
                                          fn->getName(), dest);
                 newfn->copyAttributesFrom(fn);
-                newfn->setComdat(fn->getComdat()); // copyAttributesFrom does not copy comdats
+                newfn->setComdat(
+                        fn->getComdat());  // copyAttributesFrom does not copy comdats
             }
             if (!fn->isDeclaration() && newfn->isDeclaration() && copyGlobal(fn, data)) {
                 for (Function::arg_iterator II = newfn->arg_begin(), I = fn->arg_begin(),

--- a/tests/benchmark_fannkuchredux.t
+++ b/tests/benchmark_fannkuchredux.t
@@ -6,11 +6,10 @@
  
  ]]
 
-local C = {
-    printf = terralib.externfunction("printf", terralib.types.funcpointer(rawstring,int,true)),
-    exit = terralib.externfunction("exit", int -> {}),
-    atoi = terralib.externfunction("atoi", rawstring -> int)
-}
+C = terralib.includecstring [[
+#include<stdio.h>
+#include<stdlib.h>
+]]
 
 -- this depends highly on the platform.  It might be faster to use
 -- char type on 32-bit systems; it might be faster to use unsigned.
@@ -147,7 +146,7 @@ end))
 local N = assert(tonumber((...) or 10))
 doit(N)
 if jit.os == "Windows" then
-  terralib.saveobj("benchmark_fannkuchredux.exe", { main = main }, {"\\legacy_stdio_definitions.lib"})
+  terralib.saveobj("benchmark_fannkuchredux.exe", { main = main })
   os.execute("benchmark_fannkuchredux.exe "..N)
 else
   terralib.saveobj("benchmark_fannkuchredux", { main = main })

--- a/tests/benchmark_nbody.t
+++ b/tests/benchmark_nbody.t
@@ -2,10 +2,9 @@ local C = terralib.includecstring[[
 
 #include <math.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 ]]
-
-C.printf = terralib.externfunction("printf", terralib.types.funcpointer(rawstring,int,true))
 
 pi = 3.141592653589793
 solar_mass = (4 * pi * pi)
@@ -144,7 +143,7 @@ if jit.os ~= "Windows" then
   terralib.saveobj("benchmark_nbody",{ main = main }, {"-lm"} )
   os.execute("./benchmark_nbody "..tostring(N))
 else
-  terralib.saveobj("benchmark_nbody.exe",{ main = main }, {"\\legacy_stdio_definitions.lib"} )
+  terralib.saveobj("benchmark_nbody.exe",{ main = main } )
   os.execute("benchmark_nbody.exe "..tostring(N))
 end
 

--- a/tests/run
+++ b/tests/run
@@ -6,12 +6,6 @@ local lscmd
 if ffi.os == "Windows" then
     lscmd = "cmd /c dir /b /s"
     
-    -- FIXME: https://github.com/zdevito/terra/issues/401
-    table.insert(skip, "class2.t")
-    table.insert(skip, "stdio.t")
-    table.insert(skip, "speed.t")
-    table.insert(skip, "benchmark_nbody.t")
-    table.insert(skip, "benchmark_fannkuchredux.t")
     -- Disabled due to non-deterministic failures on certain branches: https://github.com/zdevito/terra/issues/404
     table.insert(skip, "leaktest.t")
 else

--- a/tests/speed.t
+++ b/tests/speed.t
@@ -1,7 +1,7 @@
 local C = terralib.includecstring [[ 
     #include <stdlib.h>
+    #include <stdio.h>
 ]]
-C.printf = terralib.externfunction("printf", terralib.types.funcpointer(rawstring,int,true))
 
 terra doit(N : int64)
     var cur,last = 1ULL,1ULL
@@ -27,4 +27,4 @@ local test = require("test")
 print(what())
 print(test.time( function() doit:compile() end))
 print(test.time( function() doit(100000000) end))
-print(test.time( function() terralib.saveobj("speed",{main = main}, (jit.os == "Windows" and {"\\legacy_stdio_definitions.lib"} or nil)) end))
+print(test.time( function() terralib.saveobj("speed",{main = main}) end))


### PR DESCRIPTION
This fixes #401 by compensating for what is probably an LLVM bug in `copyAttributesFrom` which doesn't actually copy over the `comdat` attributes. Either that, or LLVM doesn't consider `comdat` a traditional attribute. The actual fix here is a single line of code: `newfn->setComdat(fn->getComdat());`. Everything else is either just to improve MSVC compatibility, or is the stdio workaround being removed from the tests.

A separate bug may need to be filed upstream to LLVM.